### PR TITLE
feat: TASK-0001 plan OpenAPI extraction roadmap

### DIFF
--- a/plan/TASK-0001-openapi-extraction-plan.md
+++ b/plan/TASK-0001-openapi-extraction-plan.md
@@ -1,0 +1,75 @@
+# TASK-0001 OpenAPI Extraction Planning
+
+## Objectives
+- Produce an actionable roadmap for converting the Proxmox API viewer content (https://pve.proxmox.com/pve-docs/api-viewer/) into an OpenAPI (Swagger) specification.
+- Define sub tasks that can be executed independently to minimize merge conflicts.
+- Align implementation with a Node.js + TypeScript + Playwright tooling stack, optionally complementing the pipeline with Python 3 utilities when advantageous.
+
+## Assumptions & Constraints
+- Web scraping must respect Proxmox rate limits and terms of service; requests should be throttled and cached locally.
+- Output must conform to OpenAPI 3.0+ and leverage canonical schema/type generators when available.
+- Repository currently contains mostly placeholder content; we will introduce new automation in dedicated directories.
+
+## Proposed Workstreams & Sub Tasks
+
+### 1. TASK-0002 Bootstrap tooling and repository structure
+- [ ] Verify Node.js, TypeScript, and Playwright versions; add or update project configuration (tsconfig, playwright.config, lint rules).
+- [ ] Establish directory structure for scrapers (`src/scraper`), parsers (`src/parser`), OpenAPI emitters (`src/openapi`), and data fixtures (`data/raw`, `data/processed`).
+- [ ] Add npm scripts for scraping, transforming, and validating outputs.
+- [ ] Document local setup steps in README.
+
+### 2. TASK-0003 Automate API viewer data acquisition
+- [ ] Implement a Playwright crawler that enumerates all API nodes/endpoints from the Proxmox API viewer, saving normalized JSON snapshots.
+- [ ] Handle authentication-less browsing with retries, request throttling, and local caching to prevent repeated downloads.
+- [ ] Serialize raw endpoint metadata (methods, paths, parameters, descriptions, responses) to `data/raw` with deterministic filenames.
+- [ ] Capture supplemental reference docs (enums, schemas) when available.
+
+### 3. TASK-0004 Normalize and enrich scraped metadata
+- [ ] Parse raw snapshots into structured TypeScript models that reflect canonical Proxmox API schema.
+- [ ] Resolve nested navigation (e.g., child endpoints, parameter inheritance) and flatten into discrete endpoint records.
+- [ ] Create mapping tables for data types, enums, and special cases (e.g., permission requirements).
+- [ ] Store enriched artifacts in `data/processed` for downstream consumption.
+
+### 4. TASK-0005 Generate OpenAPI specification
+- [ ] Implement transformers that convert processed metadata into OpenAPI components (paths, schemas, parameters, responses).
+- [ ] Ensure output meets OpenAPI 3.0 compliance using a validator (e.g., `swagger-cli` or `spectral`).
+- [ ] Support incremental regeneration to keep specs up to date when upstream docs change.
+- [ ] Emit versioned specs under `openapi/proxmox-{date}.yaml`.
+
+### 5. TASK-0006 Quality assurance & CI integration
+- [ ] Create automated tests for scraper (structure assertions) and transformers (snapshot or schema-based tests).
+- [ ] Add CI workflow to run scraping (mocked or cached), transformation, validation, and linting.
+- [ ] Provide manual QA checklist covering spot-checks of critical endpoints and comparison against original docs.
+
+### 6. TASK-0007 Documentation & developer experience
+- [ ] Update README with end-to-end usage instructions, architecture diagram, and maintenance guidelines.
+- [ ] Publish contribution guidelines clarifying task ownership to minimize merge conflicts.
+- [ ] Document release process for publishing updated OpenAPI specs.
+
+## Cross-cutting Considerations
+- Establish shared TypeScript interfaces in a dedicated `@types` folder to prevent drift between modules.
+- Consider optional Python utilities (e.g., for complex YAML transformations) but ensure primary workflow remains Node.js/TypeScript-based.
+- Implement caching layers (filesystem or simple database) to decouple scraping from transformation stages.
+- Track command outputs and troubleshooting notes in `versions/` changelog entries per task.
+
+## Dependencies & Open Questions
+- Determine if the API viewer exposes rate limiting or requires authentication for private endpoints.
+- Investigate how Proxmox documents data types (e.g., `integer`, `string`, custom enums) to map them accurately to OpenAPI schemas.
+- Decide whether to include example payloads or auto-generate them based on type metadata.
+
+## Milestones & Deliverables
+1. **Initial tooling bootstrap (TASK-0002)** — CI-ready scaffold with empty pipelines.
+2. **Scraping MVP (TASK-0003)** — Raw JSON dump representing the full API surface.
+3. **Normalized dataset (TASK-0004)** — Type-safe intermediate representation.
+4. **OpenAPI v1 release (TASK-0005)** — Validated OpenAPI YAML checked into repo.
+5. **Automation & docs complete (TASK-0006 & TASK-0007)** — Tests, CI, and contributor guidance finalized.
+
+## Risk Management
+- Mitigate scraping failures with robust retry/backoff strategies and snapshot-based development.
+- Guard against API viewer layout changes by isolating selectors and adding monitoring tests.
+- Keep subtasks small and decoupled to enable parallel development and reduce merge conflicts.
+
+## Next Steps
+- Review and approve the plan with stakeholders.
+- Spin up TASK-0002 to begin implementing the tooling scaffold.
+- Establish regular sync to update progress across subtasks.

--- a/plan/change-log.md
+++ b/plan/change-log.md
@@ -1,0 +1,5 @@
+# Plan Change Log
+
+## 2024-06-20
+- Initialized TASK-0001 planning document outlining multi-task roadmap for Proxmox API OpenAPI extraction.
+- Identified follow-up subtasks (TASK-0002 through TASK-0007) to parallelize implementation and reduce merge conflicts.

--- a/tasks/TASK-0001-plan-openapi-extraction.md
+++ b/tasks/TASK-0001-plan-openapi-extraction.md
@@ -1,0 +1,82 @@
+Title
+- Plan OpenAPI extraction for Proxmox API documentation.
+
+Source of truth
+- README.md (project overview).
+
+Scope
+- Focus areas: `plan/`, `tasks/`, `versions/` documentation assets.
+- Out of scope: Application source, build artifacts, runtime code.
+- Data model and types: Not applicable (planning documentation only).
+
+Allowed changes
+- Documentation under the focus areas.
+- No source code or schema changes.
+
+Branch
+- feature/20240620---task-0001-plan-openapi-extraction
+
+Preconditions
+- Run: source .env (if exists)
+- Ensure required CLIs are authenticated if needed.
+- Confirm repository PR template and standard scripts.
+
+Plan checklist
+- [ ] Read the Source of Truth in order. Extract requirements into a short list.
+- [ ] If the project syncs schema or types from a remote system, trigger the sync on the target branch.
+      Example with GitHub CLI:
+      - [ ] gh workflow run "<WORKFLOW NAME>" --ref <BRANCH>
+      - [ ] Verify updated schema, seed data, and generated types.
+- [ ] Audit the current implementation in the focus area.
+      - [ ] Trace data flow from settings or inputs through persistence to output.
+      - [ ] Identify missing mappings or dead configuration.
+- [ ] Implement changes with small, focused commits.
+      - [ ] Keep models aligned with generated types or schemas.
+      - [ ] Remove unused config and wire only supported options end to end.
+- [ ] Wire persistence and retrieval.
+      - [ ] Validate input values.
+      - [ ] Persist to storage or API and read back.
+      - [ ] Handle undefined and default values.
+- [ ] Tests and checks.
+      - [ ] source .env
+      - [ ] Install dependencies.
+      - [ ] Run linter.
+      - [ ] Build project or artifacts.
+      - [ ] Run unit and integration tests.
+- [ ] Functional QA.
+      - [ ] Verify expected behavior on key user flows or endpoints.
+      - [ ] Confirm no regressions in critical paths.
+- [ ] Documentation.
+      - [ ] Update docs only if behavior changed. Keep changes concise.
+- [ ] Commits using Conventional Commits.
+      - [ ] feat(...), fix(...), chore(...), docs(...), refactor(...)
+- [ ] Open PR.
+      - [ ] Use the repo PR template.
+      - [ ] Title: feat: TASK-0001 {short description}
+      - [ ] Body: link this task file, paste checklist, tick completed items, list deferrals.
+- [ ] Changelog.
+      - [ ] Create versions/CHANGELOG-TASK-0001-{PR or short hash}-1.md
+      - [ ] Include the command log, key decisions, and outcomes.
+- [ ] Done.
+      - [ ] Mark remaining boxes as - [ ] (defer) with reasons.
+
+Acceptance criteria
+- Requirements from the Source of Truth are implemented and testable.
+- Models align with the canonical schema and generated types.
+- All acceptance commands pass.
+- Behavior is verified by QA steps relevant to the change.
+- PR is open with template, checklist, and task link.
+- Changelog file exists and is human readable.
+
+Acceptance commands template
+- Environment
+  - source .env (if exists)
+- Optional schema or types sync
+  - Trigger CI/CLI sync if applicable and verify updated artifacts.
+- Install and checks
+  - Install dependencies
+  - Run linter
+  - Build artifacts
+- Tests
+  - Run unit tests
+  - Run integration and/or end-to-end tests as applicable

--- a/versions/CHANGELOG-TASK-0001-plan-1.md
+++ b/versions/CHANGELOG-TASK-0001-plan-1.md
@@ -1,0 +1,15 @@
+# TASK-0001 Change Log (Revision 1)
+
+## Summary
+- Created task definition and planning documents for extracting Proxmox API documentation into OpenAPI format.
+- Established follow-up subtasks (TASK-0002..TASK-0007) covering tooling, scraping, normalization, OpenAPI generation, QA, and documentation.
+- Recorded initial change log entry under `plan/change-log.md`.
+
+## Command Log
+- `git checkout -b feature/20240620---task-0001-plan-openapi-extraction`
+- `mkdir -p tasks plan versions`
+- `cat README.md`
+- Authored `tasks/TASK-0001-plan-openapi-extraction.md`
+- Authored `plan/TASK-0001-openapi-extraction-plan.md`
+- Authored `plan/change-log.md`
+- Authored `versions/CHANGELOG-TASK-0001-plan-1.md`


### PR DESCRIPTION
## Summary
- add TASK-0001 task definition describing scope and constraints for Proxmox API OpenAPI extraction
- capture detailed multi-task implementation plan and associated change log entries

## Testing
- not run (documentation-only change)

## Task
- [TASK-0001](tasks/TASK-0001-plan-openapi-extraction.md)

## Checklist
- [x] Sources read in order
- [ ] Canonical schema and types verified or synced
- [x] Implementation aligned with requirements
- [ ] Tests, lint, build passed
- [ ] QA completed for key flows
- [x] Changelog created
- [x] Deferrals documented if any

## Deferrals
- [ ] (defer) Canonical schema and types verified or synced — No canonical schemas are available for this planning-only task.
- [ ] (defer) Tests, lint, build passed — No executable code changed.
- [ ] (defer) QA completed for key flows — Documentation-only update.


------
https://chatgpt.com/codex/tasks/task_e_68daa7932438832385740179dd1abfea