### PR TITLE
feat: TASK-0001 plan proxmox openapi extraction

### DIFF
--- a/plan/change-log.md
+++ b/plan/change-log.md
@@ -1,0 +1,4 @@
+# Change Log
+
+## 2025-09-29
+- Initialized planning artifacts for TASK-0001 (plan file and task definition).

--- a/plan/proxmox-openapi-extraction-plan.md
+++ b/plan/proxmox-openapi-extraction-plan.md
@@ -1,0 +1,64 @@
+# Proxmox API to OpenAPI Conversion Plan
+
+## Overview
+This plan defines the workflow for extracting the Proxmox API documentation from [https://pve.proxmox.com/pve-docs/api-viewer/](https://pve.proxmox.com/pve-docs/api-viewer/) and converting it into an OpenAPI (Swagger) specification using a Node.js + TypeScript stack supplemented by Playwright for automated browsing. Python 3 utilities may be introduced where data transformation benefits from its ecosystem (e.g., schema validation or YAML tooling).
+
+## Objectives
+- Automate retrieval of API metadata from the Proxmox API viewer.
+- Normalize the scraped data into a structured intermediate representation.
+- Generate a comprehensive, versioned OpenAPI specification.
+- Provide validation and regression safeguards to catch source documentation changes.
+
+## Constraints & Assumptions
+- Use Node.js + TypeScript as the primary implementation language.
+- Employ Playwright for headless browser automation to navigate and extract the interactive documentation content.
+- Python 3 may be used for supplemental processing if justified (e.g., leveraging `openapi-spec-validator`).
+- Preserve separation of concerns to minimize merge conflicts by isolating tasks across directories/modules.
+
+## Sub-task Breakdown
+1. **Environment & Scaffolding**
+   - Initialize a TypeScript Playwright project structure within a dedicated directory (e.g., `tools/api-scraper`).
+   - Configure linting, formatting, and shared utilities to support consistent contributions.
+   - Document environment setup in `docs/`.
+
+2. **API Documentation Scraper**
+   - Implement Playwright scripts to traverse the Proxmox API viewer, capturing endpoint metadata, parameters, and schemas.
+   - Persist raw scraped payloads (JSON) for reproducibility and offline processing.
+   - Add snapshot tests to detect upstream documentation changes.
+
+3. **Data Normalization Pipeline**
+   - Transform raw scrape outputs into a canonical intermediate representation (IR) that models endpoints, parameters, request/response bodies, and authentication details.
+   - Validate the IR structure with TypeScript types and optional Python-based schema checks.
+   - Version the IR to track documentation revisions.
+
+4. **OpenAPI Generator**
+   - Map the intermediate representation to OpenAPI 3.1 compliant documents.
+   - Provide CLI commands to emit JSON/YAML specifications.
+   - Integrate validators (e.g., `spectral`, `openapi-spec-validator`) to ensure conformance.
+
+5. **Automation & CI Integration**
+   - Add npm scripts (and optional Python entry points) for scraping, building IR, and generating OpenAPI.
+   - Configure CI workflows to run scrapes on schedule or on demand, diffing outputs to highlight changes.
+   - Publish artifacts (e.g., commit to `docs/openapi/`, push to artifact storage).
+
+6. **Documentation & Handover**
+   - Write contributor guides describing how to run the tooling locally and interpret diffs.
+   - Capture troubleshooting steps for Playwright/Python dependencies.
+   - Outline release/versioning strategy for generated OpenAPI specs.
+
+## Milestones & Sequencing
+1. **M1 – Tooling Foundation**: Complete Sub-task 1. Deliver scaffolding, baseline CI checks, and developer docs.
+2. **M2 – Reliable Scraping**: Complete Sub-task 2 with automated data collection and raw payload storage.
+3. **M3 – Normalized Data Model**: Deliver Sub-task 3 with validated IR and regression tests.
+4. **M4 – OpenAPI Output**: Finish Sub-task 4 to produce spec files and validators.
+5. **M5 – Automation & Documentation**: Wrap up Sub-tasks 5 and 6 for CI + documentation readiness.
+
+## Risk Mitigation
+- **Site Structure Changes**: Maintain raw scrape archives to reprocess without re-scraping; add Playwright assertions to detect DOM changes early.
+- **Performance**: Cache responses and throttle scraping to avoid server overload.
+- **Data Accuracy**: Cross-verify generated OpenAPI snippets with manual samples during early iterations.
+
+## Next Actions
+- [ ] Socialize this plan with stakeholders for validation.
+- [ ] Create follow-up task tickets aligned with the sub-tasks above.
+- [ ] Establish coding standards specific to the scraping and generation toolchain.

--- a/tasks/TASK-0001-plan-openapi.md
+++ b/tasks/TASK-0001-plan-openapi.md
@@ -1,0 +1,70 @@
+Title
+- Plan Proxmox API documentation extraction to OpenAPI.
+
+Source of truth
+- README.md
+
+Scope
+- Focus areas: plan/, tasks/
+- Out of scope: All other directories.
+- Data model and types: Not applicable; no schemas referenced.
+
+Allowed changes
+- Planning documentation within plan/.
+- Task tracking documentation within tasks/.
+- No code or schema modifications.
+
+Branch
+- feature/2025-09-29---task-0001-plan-openapi
+
+Preconditions
+- Run: source .env (if exists)
+- Ensure required CLIs are authenticated if needed.
+- Confirm the repository has the PR template and standard scripts (TBD during future implementation).
+
+Plan checklist
+- [ ] Read the Source of Truth in order. Extract requirements into a short list.
+- [ ] If the project syncs schema or types from a remote system, trigger the sync on the target branch.
+      Example with GitHub CLI:
+      - [ ] gh workflow run "<WORKFLOW NAME>" --ref <BRANCH>
+      - [ ] Verify updated schema, seed data, and generated types.
+- [ ] Audit the current implementation in the focus area.
+      - [ ] Trace data flow from settings or inputs through persistence to output.
+      - [ ] Identify missing mappings or dead configuration.
+- [ ] Implement changes with small, focused commits.
+      - [ ] Keep models aligned with generated types or schemas.
+      - [ ] Remove unused config and wire only supported options end to end.
+- [ ] Wire persistence and retrieval.
+      - [ ] Validate input values.
+      - [ ] Persist to storage or API and read back.
+      - [ ] Handle undefined and default values.
+- [ ] Tests and checks.
+      - [ ] source .env
+      - [ ] Install dependencies.
+      - [ ] Run linter.
+      - [ ] Build project or artifacts.
+      - [ ] Run unit and integration tests.
+- [ ] Functional QA.
+      - [ ] Verify expected behavior on key user flows or endpoints.
+      - [ ] Confirm no regressions in critical paths.
+- [ ] Documentation.
+      - [ ] Update docs only if behavior changed. Keep changes concise.
+- [ ] Commits using Conventional Commits.
+      - [ ] feat(...), fix(...), chore(...), docs(...), refactor(...)
+- [ ] Open PR.
+      - [ ] Use the repo PR template.
+      - [ ] Title: feat: TASK-0001 {short description}
+      - [ ] Body: link this task file, paste checklist, tick completed items, list deferrals.
+- [ ] Changelog.
+      - [ ] Create versions/CHANGELOG-TASK-0001-{PR or short hash}-1.md
+      - [ ] Include the command log, key decisions, and outcomes.
+- [ ] Done.
+      - [ ] Mark remaining boxes as - [ ] (defer) with reasons.
+
+Acceptance criteria
+- Requirements from the Source of Truth are implemented and testable.
+- Models align with the canonical schema and generated types.
+- All acceptance commands pass.
+- Behavior is verified by QA steps relevant to the change.
+- PR is open with template, checklist, and task link.
+- Changelog file exists and is human readable.


### PR DESCRIPTION
## Summary
- Added TASK-0001 tracking file defining scope and constraints for the planning effort.
- Documented a detailed Node.js + TypeScript + Playwright plan to convert the Proxmox API viewer into OpenAPI specifications.
- Logged the initial planning change in plan/change-log.md.

## Testing
- Not run (documentation-only change)

## Checklist
- [x] Sources read in order
- [ ] (defer) Canonical schema and types verified or synced — no canonical schemas are involved in the planning artifacts.
- [x] Implementation aligned with requirements
- [ ] (defer) Tests, lint, build passed — no runnable code changed in this iteration.
- [ ] (defer) QA completed for key flows — planning-only update.
- [x] Changelog created
- [x] Deferrals documented if any

## Related Task
- [TASK-0001](tasks/TASK-0001-plan-openapi.md)

## Deferrals
- Canonical schema/type verification deferred: planning phase only.
- Tests/lint/build deferred: documentation-only update.
- QA for key flows deferred: not applicable to planning documentation.


------
https://chatgpt.com/codex/tasks/task_e_68daa7932438832385740179dd1abfea