### PR TITLE
feat: TASK-0014 github templates

### DIFF
--- a/.github/commit_template.txt
+++ b/.github/commit_template.txt
@@ -1,0 +1,14 @@
+# Conventional Commit template
+# type(scope?): short summary imperative mood
+# Examples of type: feat, fix, chore, docs, refactor, test, build, ci
+# Scope is optional but recommended (e.g., tooling, docs).
+
+type(scope?): short summary
+
+# Body: explain motivation and context. Wrap at 72 characters.
+# - Use bullet points for key details.
+# - Reference related tasks or issues when applicable.
+
+# Footer (optional)
+# BREAKING CHANGE: describe what changed and what to do.
+# Task: TASK-XXXX

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+- _List the key changes introduced by this pull request._
+
+## Linked Task
+- _Link to the corresponding task file (e.g., `tasks/TASK-XXXX-slug.md`)._
+
+## Testing
+- _Document the exact commands executed. Prefix each command with ✅/⚠️/❌ to indicate status._
+
+## Checklist
+- [ ] Sources read in order
+- [ ] Canonical schema and types verified or synced
+- [ ] Implementation aligned with requirements
+- [ ] Tests, lint, build passed
+- [ ] QA completed for key flows
+- [ ] Changelog created
+- [ ] Deferrals documented if any
+
+## Additional Notes
+- _Capture deferrals, follow-up work, or context for reviewers._

--- a/tasks/TASK-0014-github-templates.md
+++ b/tasks/TASK-0014-github-templates.md
@@ -1,0 +1,82 @@
+Title
+- Add GitHub contribution templates.
+
+Source of truth
+- README.md
+
+Scope
+- Focus areas. .github/ directory and related configuration files.
+- Out of scope. Application source under app/, public/.
+- Data model and types. Not applicable; no schema changes.
+
+Allowed changes
+- Repository configuration files within scope.
+- No runtime code changes unless strictly necessary.
+- No schema edits.
+
+Branch
+- feature/20250929---task-0014-github-templates
+
+Preconditions
+- Run: source .env (if exists)
+- Ensure required CLIs are authenticated.
+- Confirm the repository has the PR template and standard scripts.
+
+Plan checklist
+- [x] Read the Source of Truth in order. Extract requirements into a short list.
+- [ ] (defer) If the project syncs schema or types from a remote system, trigger the sync on the target branch. No schema involved.
+      - [ ] (defer) gh workflow run "<WORKFLOW NAME>" --ref <BRANCH>
+      - [ ] (defer) Verify updated schema, seed data, and generated types.
+- [x] Audit the current implementation in the focus area.
+      - [ ] (defer) No existing templates to trace through data flows.
+      - [ ] (defer) No configuration mappings present for template setup.
+- [x] Implement changes with small, focused commits.
+      - [ ] (defer) Keep models aligned with generated types or schemas.
+      - [ ] (defer) Remove unused config and wire only supported options end to end.
+- [ ] (defer) Wire persistence and retrieval. Not applicable to template configuration.
+      - [ ] (defer) Validate input values.
+      - [ ] (defer) Persist to storage or API and read back.
+      - [ ] (defer) Handle undefined and default values.
+- [ ] (defer) Tests and checks. Not required for template-only change.
+      - [ ] (defer) source .env — configuration-only change.
+      - [ ] (defer) Install dependencies — not required for template addition.
+      - [ ] (defer) Run linter — templates not linted.
+      - [ ] (defer) Build project or artifacts — no build impact.
+      - [ ] (defer) Run unit and integration tests — no runtime changes.
+- [ ] (defer) Functional QA. Templates do not affect runtime behavior.
+      - [ ] (defer) Verify expected behavior on key user flows or endpoints.
+      - [ ] (defer) Confirm no regressions in critical paths.
+- [ ] (defer) Documentation. No documentation updates required for template addition.
+      - [ ] (defer) No documentation updates required for template addition.
+- [x] Commits using Conventional Commits.
+      - [x] feat(...), fix(...), chore(...), docs(...), refactor(...)
+- [x] Open PR.
+      - [x] Use the repo PR template.
+      - [x] Title: feat: TASK-0014 github templates
+      - [x] Body: link this task file, paste checklist, tick completed items, list deferrals.
+- [x] Changelog.
+      - [x] Create versions/CHANGELOG-TASK-0014-f7b49c4-1.md
+      - [x] Include the command log, key decisions, and outcomes.
+- [x] Done.
+      - [x] Mark remaining boxes as - [ ] (defer) with reasons.
+
+Acceptance criteria
+- Requirements from the Source of Truth are implemented and testable.
+- Models align with the canonical schema and generated types.
+- All acceptance commands pass.
+- Behavior is verified by QA steps relevant to the change.
+- PR is open with template, checklist, and task link.
+- Changelog file exists and is human readable.
+
+Acceptance commands template
+- Environment
+  - source .env (if exists)
+- Optional schema or types sync
+  - Trigger CI/CLI sync if applicable and verify updated artifacts.
+- Install and checks
+  - Install dependencies
+  - Run linter
+  - Build artifacts
+- Tests
+  - Run unit tests
+  - Run integration and/or end-to-end tests as applicable

--- a/versions/CHANGELOG-TASK-0014-f7b49c4-1.md
+++ b/versions/CHANGELOG-TASK-0014-f7b49c4-1.md
@@ -1,0 +1,23 @@
+# TASK-0014 GitHub Templates
+
+## Summary
+- Added standardized pull request and commit message templates under `.github/`.
+- Recorded task tracking updates highlighting deferred steps for configuration-only work.
+
+## Command log
+- ls -a
+- find .. -name AGENTS.md -print
+- git status -sb
+- git checkout -b feature/20250929---task-0014-github-templates
+- sed -n '1,160p' README.md
+- cat <<'EOF' > tasks/TASK-0014-github-templates.md
+- mkdir -p .github
+- cat <<'EOF' > .github/pull_request_template.md
+- cat <<'EOF' > .github/commit_template.txt
+- apply_patch (multiple updates to plan checklist)
+- git add .github
+- git commit -m "chore(github): add contribution templates"
+- apply_patch (update task checklist for deferrals and completion)
+
+## Notes
+- Tests, builds, and QA steps deferred because template additions do not affect runtime behavior.


### PR DESCRIPTION
## Summary
- Add standardized pull request and commit message templates under `.github/` to guide future contributions.
- Record task progress and changelog entries capturing deferred checks for configuration-only work.

## Linked Task
- [TASK-0014](tasks/TASK-0014-github-templates.md)

## Testing
- ⚠️ _No automated commands executed; template-only change._

## Checklist
- [x] Sources read in order
- [ ] Canonical schema and types verified or synced
- [x] Implementation aligned with requirements
- [ ] Tests, lint, build passed
- [ ] QA completed for key flows
- [x] Changelog created
- [x] Deferrals documented if any

## Additional Notes
- Schema sync, automated checks, and QA were deferred because the update only introduces repository metadata templates.


------
https://chatgpt.com/codex/tasks/task_e_68db0b7bcecc8323a68378470fd845b8