### PR TITLE
feat: TASK-0014 add GitHub contribution templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+- _Describe the key changes introduced in this PR._
+
+## Testing
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] `npm test`
+
+## Task Reference
+- [ ] Linked task: <!-- e.g. [TASK-0014](../tasks/TASK-0014-github-templates.md) -->
+
+## Checklist
+- [ ] Sources read in order
+- [ ] Canonical schema and types verified or synced
+- [ ] Implementation aligned with requirements
+- [ ] Tests, lint, build passed
+- [ ] QA completed for key flows
+- [ ] Changelog created
+- [ ] Deferrals documented if any
+
+## Notes
+- _Add any context for reviewers here._

--- a/.github/commit_template.md
+++ b/.github/commit_template.md
@@ -1,0 +1,17 @@
+type(scope?): short summary in present tense
+
+# Provide additional context in the body after a blank line.
+# - Explain the motivation for the change.
+# - Highlight key implementation details or trade-offs.
+# - Reference issues or tasks when helpful.
+#
+# For multiple bullet points, you can use a list:
+# - First detail
+# - Second detail
+#
+# If the change introduces a breaking change, add the following section:
+#
+# BREAKING CHANGE: describe what breaks and required follow-up actions
+#
+# Types: feat, fix, chore, docs, refactor, test, build, ci, perf, style, revert
+# Scope is optional. Examples: feat(api): add new route, fix: correct typo

--- a/tasks/TASK-0014-github-templates.md
+++ b/tasks/TASK-0014-github-templates.md
@@ -1,0 +1,82 @@
+Title
+- Create GitHub templates for commits and PRs.
+
+Source of truth
+- README.md
+
+Scope
+- Focus areas. .github directory.
+- Out of scope. All application source directories (app, public, tools, etc.).
+- Data model and types. Not applicable; follow existing documentation.
+
+Allowed changes
+- Add configuration or templates under .github.
+- No application code changes.
+
+Branch
+- feature/2025-09-29---task-0014-github-templates
+
+Preconditions
+- Run: source .env (if exists)
+- Ensure required CLIs are authenticated. Example: gh, test runners, deployment tools.
+- Confirm the repository has the PR template and standard scripts.
+
+Plan checklist
+- [x] Read the Source of Truth in order. Extract requirements into a short list.
+- [ ] (defer) No remote schema or type sync required for documentation-only changes.
+      Example with GitHub CLI:
+-      - [ ] (defer) No workflows triggered for this task.
+-      - [ ] (defer) No schema artifacts to verify.
+- [x] Audit the current implementation in the focus area.
+      - [ ] (defer) No runtime data flow for template configuration.
+      - [ ] (defer) No existing mappings applicable.
+- [x] Implement changes with small, focused commits.
+      - [ ] (defer) No models or generated types involved.
+      - [ ] (defer) No runtime configuration touched.
+- [ ] (defer) Persistence wiring not applicable to template files.
+      - [ ] (defer) No inputs to validate.
+      - [ ] (defer) No storage interactions involved.
+      - [ ] (defer) No default handling required.
+- [ ] (defer) Tests and automated checks not run for documentation-only changes.
+      - [ ] (defer) Environment sourcing not needed beyond initial run.
+      - [ ] (defer) Dependencies unchanged.
+      - [ ] (defer) Linting not applicable to Markdown-only updates.
+      - [ ] (defer) No build artifacts generated.
+      - [ ] (defer) No code paths exercised by tests.
+- [ ] (defer) Functional QA not required for template additions.
+      - [ ] (defer) No user flows affected.
+      - [ ] (defer) No critical paths impacted.
+- [x] Documentation.
+      - [ ] (defer) No additional docs beyond templates required.
+- [x] Commits using Conventional Commits.
+      - [x] feat(...), fix(...), chore(...), docs(...), refactor(...)
+- [ ] Open PR.
+      - [ ] Use the repo PR template.
+      - [ ] Title: feat: TASK-0014 {short description}
+      - [ ] Body: link this task file, paste checklist, tick completed items, list deferrals.
+- [x] Changelog.
+      - [x] Create versions/CHANGELOG-TASK-0014-{PR or short hash}-1.md
+      - [x] Include the command log, key decisions, and outcomes.
+- [ ] Done.
+      - [ ] Mark remaining boxes as - [ ] (defer) with reasons.
+
+Acceptance criteria
+- Requirements from the Source of Truth are implemented and testable.
+- Models align with the canonical schema and generated types.
+- All acceptance commands pass.
+- Behavior is verified by QA steps relevant to the change.
+- PR is open with template, checklist, and task link.
+- Changelog file exists and is human readable.
+
+Acceptance commands template
+- Environment
+  - source .env (if exists)
+- Optional schema or types sync
+  - Trigger CI/CLI sync if applicable and verify updated artifacts.
+- Install and checks
+  - Install dependencies
+  - Run linter
+  - Build artifacts
+- Tests
+  - Run unit tests
+  - Run integration and/or end-to-end tests as applicable

--- a/versions/CHANGELOG-TASK-0014-75d81f9-1.md
+++ b/versions/CHANGELOG-TASK-0014-75d81f9-1.md
@@ -1,0 +1,31 @@
+# TASK-0014 – Create GitHub templates (Revision 1)
+
+## Summary
+- Added a repository-wide pull request template aligning with the mandated checklist and testing commands.
+- Introduced a Conventional Commit message template under `.github/` for consistent commit authoring guidance.
+- Updated the TASK-0014 worklog to capture progress and recorded deferrals for non-applicable checklist items.
+
+## Command Log
+- `sed -n '1,160p' README.md`
+- `mkdir -p .github`
+- `cat <<'EOF' > .github/PULL_REQUEST_TEMPLATE.md`
+- `apply_patch` edits to refine template guidance and task log entries.
+- `cat <<'EOF' > .github/commit_template.md`
+- `rm .runonce`
+- `git status -sb`
+- `git rev-parse --short HEAD`
+
+## Decisions
+- Focused changes on documentation-only assets to respect the scoped directories in the task definition.
+- Prefilled the PR template with the standard checklist and acceptance commands to streamline compliance.
+- Documented skipped automation, testing, and QA steps as deferrals because the task only touched Markdown templates.
+
+## Outcomes
+- Contributors now have ready-to-use templates for both pull requests and Conventional Commit messages.
+- Repository workflow documentation remains centralized within `.github/` for discoverability.
+- Project history reflects why test-related steps were intentionally omitted.
+
+## Deferrals
+- Automated checks and builds (`npm run lint`, `npm run build`, `npm test`) – not run because no executable code changed.
+- Schema synchronization workflows – not applicable to static template updates.
+- Functional QA flows – not impacted by Markdown-only modifications.


### PR DESCRIPTION
## Summary
- add a repository-wide pull request template that embeds the standard checklist and testing commands
- introduce a conventional commit message template for contributors
- capture the TASK-0014 execution log with deferrals for out-of-scope checks

## Testing
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] `npm test`

## Task Reference
- [x] Linked task: [TASK-0014](tasks/TASK-0014-github-templates.md)

## Checklist
- [x] Sources read in order
- [ ] Canonical schema and types verified or synced _(deferred – static templates only)_
- [x] Implementation aligned with requirements
- [ ] Tests, lint, build passed _(deferred – documentation-only change)_
- [ ] QA completed for key flows _(deferred – documentation-only change)_
- [x] Changelog created
- [x] Deferrals documented if any

## Notes
- Tests, builds, and QA were not run because this update only adds Markdown templates.
- Schema/type synchronization is not applicable for template changes.


------
https://chatgpt.com/codex/tasks/task_e_68db0b7bcecc8323a68378470fd845b8