### PR TITLE
feat: TASK-0019 private GitHub Action plan

### DIFF
--- a/plan/private-github-action-plan.md
+++ b/plan/private-github-action-plan.md
@@ -1,0 +1,100 @@
+# Private GitHub Action Plan for OpenAPI Artifact Generation
+
+## Overview
+This document outlines the steps required to package the existing Proxmox API
+automation pipeline into a reusable, private GitHub Action. The action must
+run the established scrape → normalize → OpenAPI generation workflow and emit
+portable artifacts that downstream repositories can consume.
+
+## Objectives
+- Encapsulate the automation pipeline into a GitHub Action with clearly defined
+  inputs, outputs, and caching behaviour.
+- Ensure the action can operate in private repositories without exposing
+  sensitive credentials.
+- Provide release automation so new action versions can be published via
+  GitHub Actions workflows.
+- Document usage patterns for other projects to adopt the action quickly.
+
+## Constraints and assumptions
+- Reuse the existing Node.js + Playwright tooling; avoid rewriting the
+  pipeline.
+- Action consumers may not have Playwright dependencies preinstalled; the
+  action must bootstrap its environment.
+- The action should support both CI-mode (cached artifacts) and full-mode
+  (fresh scrape) executions similar to the local pipeline.
+- Artifact outputs must remain OpenAPI 3.1 compatible JSON/YAML files aligned
+  with the canonical specs committed in this repository.
+
+## Deliverables
+1. Task tickets describing the implementation phases required to deliver the
+   private action.
+2. Updated documentation detailing the action design, inputs/outputs, and
+   release process.
+
+## Implementation phases and task mapping
+
+### 1. Define action requirements and interface
+- Audit existing automation commands and identify the minimum inputs/outputs
+  the action must expose.
+- Document runtime expectations (Node version, cache directories, secrets) and
+  portability requirements.
+- Produce a design brief covering composite vs. JavaScript action trade-offs
+  and CI integration guidelines.
+- **Task**: [TASK-0020](../tasks/TASK-0020-github-action-requirements.md)
+
+### 2. Extract reusable automation entry point
+- Refactor or wrap the current `automation:pipeline` command into a dedicated
+  script that the GitHub Action can call with parameter overrides.
+- Ensure the script supports configurable output directories for downstream
+  repositories.
+- Add smoke tests validating the script executes in both CI-mode and full-mode
+  without repository-specific assumptions.
+- **Task**: [TASK-0021](../tasks/TASK-0021-github-action-entrypoint.md)
+
+### 3. Author the private GitHub Action package
+- Scaffold the `action.yml` (or composite action) with inputs for mode,
+  artifact destinations, and authentication toggles.
+- Implement dependency bootstrapping (npm install, Playwright browsers) within
+  the action runtime.
+- Wire outputs (e.g., generated artifact paths, checksum summaries) for
+  downstream workflows.
+- **Task**: [TASK-0022](../tasks/TASK-0022-github-action-package.md)
+
+### 4. Release automation workflow
+- Create a dedicated GitHub Actions workflow that versions the private action,
+  bundles required artifacts, and publishes a GitHub release tagged for the
+  action.
+- Automate changelog generation and attach built assets (if any) to the
+  release.
+- Ensure the workflow can be triggered manually and from the main branch after
+  action updates merge.
+- **Task**: [TASK-0023](../tasks/TASK-0023-github-action-release.md)
+
+### 5. Consumer onboarding and validation
+- Provide documentation for integrating the action into downstream
+  repositories, including sample workflow snippets.
+- Establish integration tests or a sandbox repository to validate the action
+  in a clean environment.
+- Capture troubleshooting guidance and versioning strategy for private usage.
+- **Task**: [TASK-0024](../tasks/TASK-0024-github-action-adoption.md)
+
+## Success criteria
+- Each implementation task references the canonical automation docs and keeps
+  generated artifacts compatible with the existing OpenAPI specs.
+- The release workflow can create tagged versions of the action without manual
+  steps.
+- Documentation enables downstream teams to onboard within a single sprint.
+
+## Risks and mitigations
+- **Dependency drift**: Pin Node.js and Playwright versions within the action
+  runtime to match repository expectations.
+- **Credential exposure**: Store secrets in organization-level environments and
+  document usage of GitHub Action secrets and encrypted variables.
+- **Artifact size**: Monitor output size and consider compressing artifacts or
+  uploading to release assets to stay within GitHub's limits.
+
+## Next steps
+- Socialize the plan with maintainers for feedback.
+- Prioritize and schedule tasks TASK-0020 through TASK-0024.
+- Begin work with requirement/interface definition to minimize rework in later
+  phases.

--- a/tasks/TASK-0019-github-action-plan.md
+++ b/tasks/TASK-0019-github-action-plan.md
@@ -1,0 +1,85 @@
+Title
+- Plan private GitHub Action for OpenAPI artifact generation.
+
+Source of truth
+- plan/proxmox-openapi-extraction-plan.md
+- docs/handover/README.md
+- docs/automation/README.md
+
+Scope
+- Focus areas: plan/, tasks/
+- Out of scope: app/, tools/, docs/openapi/
+- Data model and types: Existing OpenAPI artifacts and automation pipeline outputs are the ground truth.
+
+Allowed changes
+- Documentation and planning updates under plan/
+- New task definitions under tasks/
+- No code changes to tooling or schemas.
+
+Branch
+- feature/2025-09-30---task-0019-github-action-plan
+
+Preconditions
+- Run: source .env (if exists)
+- Ensure required CLIs are authenticated. Example: gh, test runners, deployment tools.
+- Confirm the repository has the PR template and standard scripts.
+
+Plan checklist
+- [x] Read the Source of Truth in order. Extract requirements into a short list.
+- [ ] (defer) If the project syncs schema or types from a remote system, trigger the sync on the target branch. No remote sync required for planning-only update.
+      Example with GitHub CLI:
+      - [ ] (defer) gh workflow run "<WORKFLOW NAME>" --ref <BRANCH>. Not applicable.
+      - [ ] (defer) Verify updated schema, seed data, and generated types. Not applicable.
+- [x] Audit the current implementation in the focus area.
+      - [x] Trace data flow from settings or inputs through persistence to output.
+      - [x] Identify missing mappings or dead configuration.
+- [x] Implement changes with small, focused commits.
+      - [x] Keep models aligned with generated types or schemas.
+      - [x] Remove unused config and wire only supported options end to end.
+- [ ] (defer) Wire persistence and retrieval. Not applicable to documentation-only plan.
+      - [ ] (defer) Validate input values. Not applicable.
+      - [ ] (defer) Persist to storage or API and read back. Not applicable.
+      - [ ] (defer) Handle undefined and default values. Not applicable.
+- [ ] (defer) Tests and checks. Documentation-only update with no executable changes.
+      - [ ] (defer) source .env. Not required; no commands executed.
+      - [ ] (defer) Install dependencies.
+      - [ ] (defer) Run linter.
+      - [ ] (defer) Build project or artifacts.
+      - [ ] (defer) Run unit and integration tests.
+- [ ] (defer) Functional QA. Documentation-only change.
+      - [ ] (defer) Verify expected behavior on key user flows or endpoints. Not applicable.
+      - [ ] (defer) Confirm no regressions in critical paths. Not applicable.
+- [x] Documentation.
+      - [x] Update docs only if behavior changed. Keep changes concise.
+- [x] Commits using Conventional Commits.
+      - [x] feat(...), fix(...), chore(...), docs(...), refactor(...)
+- [ ] Open PR.
+      - [ ] Use the repo PR template.
+      - [ ] Title: feat: TASK-0019 short description
+      - [ ] Body: link this task file, paste checklist, tick completed items, list deferrals.
+- [x] Changelog.
+      - [x] Create versions/CHANGELOG-TASK-0019-{PR or short hash}-1.md
+      - [x] Include the command log, key decisions, and outcomes.
+- [ ] Done.
+      - [ ] Mark remaining boxes as - [ ] (defer) with reasons.
+
+Acceptance criteria
+- Requirements from the Source of Truth are implemented and testable.
+- Models align with the canonical schema and generated types.
+- All acceptance commands pass.
+- Behavior is verified by QA steps relevant to the change.
+- PR is open with template, checklist, and task link.
+- Changelog file exists and is human readable.
+
+Acceptance commands template
+- Environment
+  - source .env (if exists)
+- Optional schema or types sync
+  - Trigger CI/CLI sync if applicable and verify updated artifacts.
+- Install and checks
+  - Install dependencies
+  - Run linter
+  - Build artifacts
+- Tests
+  - Run unit tests
+  - Run integration and/or end-to-end tests as applicable

--- a/tasks/TASK-0020-github-action-requirements.md
+++ b/tasks/TASK-0020-github-action-requirements.md
@@ -1,0 +1,88 @@
+Title
+- Define private GitHub Action requirements and interface.
+
+Source of truth
+- plan/private-github-action-plan.md
+- plan/proxmox-openapi-extraction-plan.md
+- docs/handover/README.md
+- docs/automation/README.md
+
+Requirements summary
+- Capture inputs, outputs, runtime expectations, and portability requirements for the private GitHub Action.
+- Document action design decisions (composite vs. JavaScript) and integration guidelines.
+
+Scope
+- Focus areas: plan/, docs/automation/, docs/handover/
+- Out of scope: tools/, app/, docs/openapi/
+- Data model and types: Existing automation pipeline outputs remain the ground truth.
+
+Allowed changes
+- Documentation updates describing the action requirements and design brief.
+- Planning artifacts outlining interface contracts.
+- No code or schema modifications.
+
+Branch
+- feature/{date}---task-0020-github-action-requirements
+
+Preconditions
+- Run: source .env (if exists)
+- Ensure required CLIs are authenticated.
+- Confirm the repository has the PR template and standard scripts.
+
+Plan checklist
+- [ ] Read the Source of Truth in order. Extract requirements into a short list.
+- [ ] If the project syncs schema or types from a remote system, trigger the sync on the target branch.
+      Example with GitHub CLI:
+      - [ ] gh workflow run "<WORKFLOW NAME>" --ref <BRANCH>
+      - [ ] Verify updated schema, seed data, and generated types.
+- [ ] Audit the current implementation in the focus area.
+      - [ ] Trace data flow from settings or inputs through persistence to output.
+      - [ ] Identify missing mappings or dead configuration.
+- [ ] Implement changes with small, focused commits.
+      - [ ] Keep models aligned with generated types or schemas.
+      - [ ] Remove unused config and wire only supported options end to end.
+- [ ] Wire persistence and retrieval.
+      - [ ] Validate input values.
+      - [ ] Persist to storage or API and read back.
+      - [ ] Handle undefined and default values.
+- [ ] Tests and checks.
+      - [ ] source .env
+      - [ ] Install dependencies.
+      - [ ] Run linter.
+      - [ ] Build project or artifacts.
+      - [ ] Run unit and integration tests.
+- [ ] Functional QA.
+      - [ ] Verify expected behavior on key user flows or endpoints.
+      - [ ] Confirm no regressions in critical paths.
+- [ ] Documentation.
+      - [ ] Update docs only if behavior changed. Keep changes concise.
+- [ ] Commits using Conventional Commits.
+      - [ ] feat(...), fix(...), chore(...), docs(...), refactor(...)
+- [ ] Open PR.
+      - [ ] Use the repo PR template.
+      - [ ] Title: feat: TASK-0020 short description
+      - [ ] Body: link this task file, paste checklist, tick completed items, list deferrals.
+- [ ] Changelog.
+      - [ ] Create versions/CHANGELOG-TASK-0020-{PR or short hash}-1.md
+      - [ ] Include the command log, key decisions, and outcomes.
+- [ ] Done.
+      - [ ] Mark remaining boxes as - [ ] (defer) with reasons.
+
+Acceptance criteria
+- Requirements and interface documentation completed.
+- No changes to automation behaviour beyond documentation.
+- All acceptance commands pass if executed.
+- Changelog captures planning work.
+
+Acceptance commands template
+- Environment
+  - source .env (if exists)
+- Optional schema or types sync
+  - Trigger CI/CLI sync if applicable and verify updated artifacts.
+- Install and checks
+  - Install dependencies
+  - Run linter
+  - Build artifacts
+- Tests
+  - Run unit tests
+  - Run integration and/or end-to-end tests as applicable

--- a/tasks/TASK-0021-github-action-entrypoint.md
+++ b/tasks/TASK-0021-github-action-entrypoint.md
@@ -1,0 +1,89 @@
+Title
+- Extract reusable automation entry point for GitHub Action.
+
+Source of truth
+- plan/private-github-action-plan.md
+- plan/proxmox-openapi-extraction-plan.md
+- docs/handover/README.md
+- docs/automation/README.md
+
+Requirements summary
+- Provide a dedicated script or CLI wrapper around `npm run automation:pipeline` for action consumption.
+- Ensure configurable inputs for mode, output directories, and artifact naming.
+- Add smoke coverage validating CI and full execution paths.
+
+Scope
+- Focus areas: tools/automation/, tools/api-*/, package.json scripts
+- Out of scope: app/, docs/openapi/, public/
+- Data model and types: Existing automation pipeline outputs.
+
+Allowed changes
+- Refactor automation scripts to expose reusable entry point.
+- Update package scripts and supporting utilities as needed.
+- No changes to generated OpenAPI schemas beyond deterministic regeneration.
+
+Branch
+- feature/{date}---task-0021-github-action-entrypoint
+
+Preconditions
+- Run: source .env (if exists)
+- Ensure required CLIs are authenticated.
+- Confirm the repository has the PR template and standard scripts.
+
+Plan checklist
+- [ ] Read the Source of Truth in order. Extract requirements into a short list.
+- [ ] If the project syncs schema or types from a remote system, trigger the sync on the target branch.
+      Example with GitHub CLI:
+      - [ ] gh workflow run "<WORKFLOW NAME>" --ref <BRANCH>
+      - [ ] Verify updated schema, seed data, and generated types.
+- [ ] Audit the current implementation in the focus area.
+      - [ ] Trace data flow from settings or inputs through persistence to output.
+      - [ ] Identify missing mappings or dead configuration.
+- [ ] Implement changes with small, focused commits.
+      - [ ] Keep models aligned with generated types or schemas.
+      - [ ] Remove unused config and wire only supported options end to end.
+- [ ] Wire persistence and retrieval.
+      - [ ] Validate input values.
+      - [ ] Persist to storage or API and read back.
+      - [ ] Handle undefined and default values.
+- [ ] Tests and checks.
+      - [ ] source .env
+      - [ ] Install dependencies.
+      - [ ] Run linter.
+      - [ ] Build project or artifacts.
+      - [ ] Run unit and integration tests.
+- [ ] Functional QA.
+      - [ ] Verify expected behavior on key user flows or endpoints.
+      - [ ] Confirm no regressions in critical paths.
+- [ ] Documentation.
+      - [ ] Update docs only if behavior changed. Keep changes concise.
+- [ ] Commits using Conventional Commits.
+      - [ ] feat(...), fix(...), chore(...), docs(...), refactor(...)
+- [ ] Open PR.
+      - [ ] Use the repo PR template.
+      - [ ] Title: feat: TASK-0021 short description
+      - [ ] Body: link this task file, paste checklist, tick completed items, list deferrals.
+- [ ] Changelog.
+      - [ ] Create versions/CHANGELOG-TASK-0021-{PR or short hash}-1.md
+      - [ ] Include the command log, key decisions, and outcomes.
+- [ ] Done.
+      - [ ] Mark remaining boxes as - [ ] (defer) with reasons.
+
+Acceptance criteria
+- Automation entry point supports configurable inputs for action usage.
+- Regression commands succeed in CI and full modes.
+- Documentation updated to reflect new entry point.
+- Deterministic artifacts maintained.
+
+Acceptance commands template
+- Environment
+  - source .env (if exists)
+- Optional schema or types sync
+  - Trigger CI/CLI sync if applicable and verify updated artifacts.
+- Install and checks
+  - Install dependencies
+  - Run linter
+  - Build artifacts
+- Tests
+  - Run unit tests
+  - Run integration and/or end-to-end tests as applicable

--- a/tasks/TASK-0022-github-action-package.md
+++ b/tasks/TASK-0022-github-action-package.md
@@ -1,0 +1,89 @@
+Title
+- Implement private GitHub Action package for OpenAPI generation.
+
+Source of truth
+- plan/private-github-action-plan.md
+- plan/proxmox-openapi-extraction-plan.md
+- docs/handover/README.md
+- docs/automation/README.md
+
+Requirements summary
+- Create the GitHub Action definition (composite or JavaScript) encapsulating the automation entry point.
+- Configure inputs for execution mode, artifact output paths, and optional overrides.
+- Ensure outputs expose artifact paths and summaries for downstream steps.
+
+Scope
+- Focus areas: .github/actions/, tools/automation/, package.json
+- Out of scope: app/, docs/openapi/
+- Data model and types: Automation pipeline outputs are authoritative.
+
+Allowed changes
+- Add action implementation files and helper scripts.
+- Update tooling dependencies if required for the action runtime.
+- No breaking changes to existing automation commands without coordination.
+
+Branch
+- feature/{date}---task-0022-github-action-package
+
+Preconditions
+- Run: source .env (if exists)
+- Ensure required CLIs are authenticated.
+- Confirm the repository has the PR template and standard scripts.
+
+Plan checklist
+- [ ] Read the Source of Truth in order. Extract requirements into a short list.
+- [ ] If the project syncs schema or types from a remote system, trigger the sync on the target branch.
+      Example with GitHub CLI:
+      - [ ] gh workflow run "<WORKFLOW NAME>" --ref <BRANCH>
+      - [ ] Verify updated schema, seed data, and generated types.
+- [ ] Audit the current implementation in the focus area.
+      - [ ] Trace data flow from settings or inputs through persistence to output.
+      - [ ] Identify missing mappings or dead configuration.
+- [ ] Implement changes with small, focused commits.
+      - [ ] Keep models aligned with generated types or schemas.
+      - [ ] Remove unused config and wire only supported options end to end.
+- [ ] Wire persistence and retrieval.
+      - [ ] Validate input values.
+      - [ ] Persist to storage or API and read back.
+      - [ ] Handle undefined and default values.
+- [ ] Tests and checks.
+      - [ ] source .env
+      - [ ] Install dependencies.
+      - [ ] Run linter.
+      - [ ] Build project or artifacts.
+      - [ ] Run unit and integration tests.
+- [ ] Functional QA.
+      - [ ] Verify expected behavior on key user flows or endpoints.
+      - [ ] Confirm no regressions in critical paths.
+- [ ] Documentation.
+      - [ ] Update docs only if behavior changed. Keep changes concise.
+- [ ] Commits using Conventional Commits.
+      - [ ] feat(...), fix(...), chore(...), docs(...), refactor(...)
+- [ ] Open PR.
+      - [ ] Use the repo PR template.
+      - [ ] Title: feat: TASK-0022 short description
+      - [ ] Body: link this task file, paste checklist, tick completed items, list deferrals.
+- [ ] Changelog.
+      - [ ] Create versions/CHANGELOG-TASK-0022-{PR or short hash}-1.md
+      - [ ] Include the command log, key decisions, and outcomes.
+- [ ] Done.
+      - [ ] Mark remaining boxes as - [ ] (defer) with reasons.
+
+Acceptance criteria
+- GitHub Action executes automation entry point with configurable inputs.
+- Generated artifacts are exposed as workflow outputs or uploaded as artifacts.
+- Action dependencies installed automatically.
+- Documentation updated with usage examples.
+
+Acceptance commands template
+- Environment
+  - source .env (if exists)
+- Optional schema or types sync
+  - Trigger CI/CLI sync if applicable and verify updated artifacts.
+- Install and checks
+  - Install dependencies
+  - Run linter
+  - Build artifacts
+- Tests
+  - Run unit tests
+  - Run integration and/or end-to-end tests as applicable

--- a/tasks/TASK-0023-github-action-release.md
+++ b/tasks/TASK-0023-github-action-release.md
@@ -1,0 +1,89 @@
+Title
+- Automate private GitHub Action release workflow.
+
+Source of truth
+- plan/private-github-action-plan.md
+- plan/proxmox-openapi-extraction-plan.md
+- docs/handover/README.md
+- docs/automation/README.md
+
+Requirements summary
+- Create a GitHub Actions workflow that builds, tags, and publishes the private action.
+- Generate GitHub releases with packaged assets and changelog entries.
+- Support manual dispatch and automatic runs on main branch merges.
+
+Scope
+- Focus areas: .github/workflows/, plan/
+- Out of scope: app/, tools/api-*, docs/openapi/
+- Data model and types: Automation pipeline outputs remain canonical.
+
+Allowed changes
+- Add release workflow YAML and supporting scripts.
+- Update documentation describing release triggers and required secrets.
+- No changes to automation logic beyond packaging for release.
+
+Branch
+- feature/{date}---task-0023-github-action-release
+
+Preconditions
+- Run: source .env (if exists)
+- Ensure required CLIs are authenticated (gh, npm, etc.).
+- Confirm the repository has the PR template and standard scripts.
+
+Plan checklist
+- [ ] Read the Source of Truth in order. Extract requirements into a short list.
+- [ ] If the project syncs schema or types from a remote system, trigger the sync on the target branch.
+      Example with GitHub CLI:
+      - [ ] gh workflow run "<WORKFLOW NAME>" --ref <BRANCH>
+      - [ ] Verify updated schema, seed data, and generated types.
+- [ ] Audit the current implementation in the focus area.
+      - [ ] Trace data flow from settings or inputs through persistence to output.
+      - [ ] Identify missing mappings or dead configuration.
+- [ ] Implement changes with small, focused commits.
+      - [ ] Keep models aligned with generated types or schemas.
+      - [ ] Remove unused config and wire only supported options end to end.
+- [ ] Wire persistence and retrieval.
+      - [ ] Validate input values.
+      - [ ] Persist to storage or API and read back.
+      - [ ] Handle undefined and default values.
+- [ ] Tests and checks.
+      - [ ] source .env
+      - [ ] Install dependencies.
+      - [ ] Run linter.
+      - [ ] Build project or artifacts.
+      - [ ] Run unit and integration tests.
+- [ ] Functional QA.
+      - [ ] Verify expected behavior on key user flows or endpoints.
+      - [ ] Confirm no regressions in critical paths.
+- [ ] Documentation.
+      - [ ] Update docs only if behavior changed. Keep changes concise.
+- [ ] Commits using Conventional Commits.
+      - [ ] feat(...), fix(...), chore(...), docs(...), refactor(...)
+- [ ] Open PR.
+      - [ ] Use the repo PR template.
+      - [ ] Title: feat: TASK-0023 short description
+      - [ ] Body: link this task file, paste checklist, tick completed items, list deferrals.
+- [ ] Changelog.
+      - [ ] Create versions/CHANGELOG-TASK-0023-{PR or short hash}-1.md
+      - [ ] Include the command log, key decisions, and outcomes.
+- [ ] Done.
+      - [ ] Mark remaining boxes as - [ ] (defer) with reasons.
+
+Acceptance criteria
+- Release workflow can create a Git tag and GitHub release for the action.
+- Release artifacts (dist bundle, metadata) are attached to the release.
+- Workflow supports manual dispatch and post-merge execution.
+- Documentation updated with release procedure.
+
+Acceptance commands template
+- Environment
+  - source .env (if exists)
+- Optional schema or types sync
+  - Trigger CI/CLI sync if applicable and verify updated artifacts.
+- Install and checks
+  - Install dependencies
+  - Run linter
+  - Build artifacts
+- Tests
+  - Run unit tests
+  - Run integration and/or end-to-end tests as applicable

--- a/tasks/TASK-0024-github-action-adoption.md
+++ b/tasks/TASK-0024-github-action-adoption.md
@@ -1,0 +1,89 @@
+Title
+- Document consumer onboarding and validation for private GitHub Action.
+
+Source of truth
+- plan/private-github-action-plan.md
+- plan/proxmox-openapi-extraction-plan.md
+- docs/handover/README.md
+- docs/automation/README.md
+
+Requirements summary
+- Produce usage documentation and sample workflows for downstream repositories.
+- Establish validation strategy via sandbox repo or integration tests.
+- Provide troubleshooting and versioning guidance for private distribution.
+
+Scope
+- Focus areas: docs/automation/, docs/handover/, plan/
+- Out of scope: tools/, app/, docs/openapi/
+- Data model and types: Generated OpenAPI specs remain authoritative outputs.
+
+Allowed changes
+- Documentation updates covering onboarding, validation, and troubleshooting.
+- Optional automation for sandbox validation workflows.
+- No changes to core automation pipeline.
+
+Branch
+- feature/{date}---task-0024-github-action-adoption
+
+Preconditions
+- Run: source .env (if exists)
+- Ensure required CLIs are authenticated.
+- Confirm the repository has the PR template and standard scripts.
+
+Plan checklist
+- [ ] Read the Source of Truth in order. Extract requirements into a short list.
+- [ ] If the project syncs schema or types from a remote system, trigger the sync on the target branch.
+      Example with GitHub CLI:
+      - [ ] gh workflow run "<WORKFLOW NAME>" --ref <BRANCH>
+      - [ ] Verify updated schema, seed data, and generated types.
+- [ ] Audit the current implementation in the focus area.
+      - [ ] Trace data flow from settings or inputs through persistence to output.
+      - [ ] Identify missing mappings or dead configuration.
+- [ ] Implement changes with small, focused commits.
+      - [ ] Keep models aligned with generated types or schemas.
+      - [ ] Remove unused config and wire only supported options end to end.
+- [ ] Wire persistence and retrieval.
+      - [ ] Validate input values.
+      - [ ] Persist to storage or API and read back.
+      - [ ] Handle undefined and default values.
+- [ ] Tests and checks.
+      - [ ] source .env
+      - [ ] Install dependencies.
+      - [ ] Run linter.
+      - [ ] Build project or artifacts.
+      - [ ] Run unit and integration tests.
+- [ ] Functional QA.
+      - [ ] Verify expected behavior on key user flows or endpoints.
+      - [ ] Confirm no regressions in critical paths.
+- [ ] Documentation.
+      - [ ] Update docs only if behavior changed. Keep changes concise.
+- [ ] Commits using Conventional Commits.
+      - [ ] feat(...), fix(...), chore(...), docs(...), refactor(...)
+- [ ] Open PR.
+      - [ ] Use the repo PR template.
+      - [ ] Title: feat: TASK-0024 short description
+      - [ ] Body: link this task file, paste checklist, tick completed items, list deferrals.
+- [ ] Changelog.
+      - [ ] Create versions/CHANGELOG-TASK-0024-{PR or short hash}-1.md
+      - [ ] Include the command log, key decisions, and outcomes.
+- [ ] Done.
+      - [ ] Mark remaining boxes as - [ ] (defer) with reasons.
+
+Acceptance criteria
+- Documentation enables downstream teams to adopt the action with minimal ramp-up.
+- Validation strategy confirmed via sandbox or integration runs.
+- Troubleshooting and versioning guidance published.
+- Acceptance commands succeed when executed.
+
+Acceptance commands template
+- Environment
+  - source .env (if exists)
+- Optional schema or types sync
+  - Trigger CI/CLI sync if applicable and verify updated artifacts.
+- Install and checks
+  - Install dependencies
+  - Run linter
+  - Build artifacts
+- Tests
+  - Run unit tests
+  - Run integration and/or end-to-end tests as applicable

--- a/versions/CHANGELOG-TASK-0019-PR-1.md
+++ b/versions/CHANGELOG-TASK-0019-PR-1.md
@@ -1,0 +1,18 @@
+# Changelog – TASK-0019
+
+## Summary
+- Created planning document for packaging the automation pipeline as a private GitHub Action.
+- Added follow-up task tickets (TASK-0020 → TASK-0024) covering requirements, entry point refactor, action implementation, release automation, and adoption documentation.
+- Updated TASK-0019 checklist to record completed planning work and deferrals for execution-specific checks.
+
+## Source materials consulted
+- plan/proxmox-openapi-extraction-plan.md
+- docs/handover/README.md
+- docs/automation/README.md
+
+## Command log
+No repository commands were executed beyond file edits; build/test workflows were deferred because this change only adds planning documentation and task tickets.
+
+## Decisions
+- Documented five sequential implementation tasks to deliver the private GitHub Action while preserving existing pipeline behaviour.
+- Chose a dedicated plan document under `plan/` to centralize objectives, risks, and success criteria for the action effort.


### PR DESCRIPTION
## Summary
- Documented a multi-phase plan to package the automation pipeline as a private GitHub Action, including objectives, risks, and success criteria.
- Added follow-up task tickets (TASK-0020 through TASK-0024) that cover requirements gathering, reusable entry point work, action packaging, release automation, and adoption guidance.
- Captured planning decisions and deferrals in the changelog and task checklist.

## Testing
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] `npm test`

## Task Reference
- [x] Linked task: [TASK-0019](../tasks/TASK-0019-github-action-plan.md)

## Checklist
- [x] Sources read in order
- [ ] Canonical schema and types verified or synced
- [x] Implementation aligned with requirements
- [ ] Tests, lint, build passed
- [ ] QA completed for key flows
- [x] Changelog created
- [x] Deferrals documented if any

## Notes
- Documentation-only update; build, lint, and test commands were deferred.

------
https://chatgpt.com/codex/tasks/task_e_68dc2c6a0e9c8323aa8f6f0e1a1d7d36