### PR TITLE
feat: TASK-0034 plan to externalize OpenAPI spec artifacts

### DIFF
--- a/plan/openapi-spec-artifact-decoupling.md
+++ b/plan/openapi-spec-artifact-decoupling.md
@@ -1,0 +1,72 @@
+# Plan: Stop committing generated OpenAPI specs
+
+## Objectives
+- Keep the OpenAPI JSON/YAML artifacts out of Git history while preserving deterministic generation.
+- Ensure local developers and CI workflows can still materialize specs on demand for the UI, regression tests, and downstream consumers.
+- Preserve regression coverage and automation parity that currently depend on `docs/openapi/proxmox-ve.{json,yaml}`.
+
+## Current state summary
+- `npm run openapi:generate` writes JSON and YAML specs to `docs/openapi/` via defaults in `tools/openapi-generator/src/cli.ts` and the automation pipeline helper in `tools/automation/src/pipeline.ts`.
+- The Remix route `app/routes/openapi.json.ts` and the Swagger UI in `app/routes/_index.tsx` read from the committed JSON file.
+- Regression checks (`tests/regression/artifacts.spec.ts`) load SHA-256 baselines defined in `tools/automation/src/regression/baselines.ts`, which point to the committed files.
+- Documentation (handover, automation README, regression checklist) instructs contributors to inspect git diffs for `docs/openapi/` artifacts, reinforcing the committed-artifact workflow.
+
+## Desired end state
+- Generated OpenAPI artifacts live under an ignored workspace directory (for example `var/openapi/`) that both CLI tools and the Remix server can read.
+- CI workflows run the automation pipeline, publish the JSON/YAML outputs as build artifacts, and fail when regeneration produces unexpected differences relative to recorded checksums.
+- Regression tests validate against stored checksums without requiring tracked spec files.
+- Documentation and developer UX guide contributors to run the pipeline locally to refresh artifacts, instead of relying on git diffs.
+
+## Step-by-step plan
+
+1. **Decide on new artifact staging directories and git hygiene**
+   - Create a shared `var/` (or `.artifacts/`) directory for generated files and add it to `.gitignore`.
+   - Update Biome configuration (`biome.json`) and any glob-based tooling to exclude the ignored artifact paths.
+   - Provide helper constants/utilities (e.g., `tools/shared/paths.ts`) to resolve the new directories consistently across packages.
+
+2. **Refactor generator and pipeline defaults**
+   - Update `tools/openapi-generator/src/cli.ts` and `tools/automation/src/pipeline.ts` so the default OpenAPI output directory points to the new ignored location.
+   - Ensure CLI flags continue to accept overrides for bespoke paths.
+   - Emit a JSON summary (already supported) that records artifact paths so downstream steps can discover files without hard-coding directories.
+
+3. **Migrate regression baselines away from tracked artifacts**
+   - Replace hard-coded `docs/openapi/` paths in `tools/automation/src/regression/baselines.ts` with references to the new artifact directory.
+   - Store expected checksums separately (e.g., in `tools/automation/data/regression/openapi.sha256.json`) that regression tests can load without requiring the spec files to be versioned.
+   - Adjust `tests/regression/artifacts.spec.ts` to invoke the automation pipeline (in CI mode) during test setup when artifacts are missing, or to read from the summary JSON emitted by the pipeline.
+
+4. **Teach the Remix app to locate runtime artifacts**
+   - Update `app/routes/openapi.json.ts` to read from the new path and surface a helpful 404 with remediation steps if the artifact is missing.
+   - Update the Swagger UI hint in `app/routes/_index.tsx` to reference the new generation workflow and artifact directory.
+   - Consider serving the OpenAPI spec via Remix data loader that proxies directly from the pipeline summary when available.
+
+5. **Update documentation and onboarding**
+   - Refresh `docs/handover/README.md`, `docs/automation/README.md`, and `docs/qa/regression-checklist.md` to describe the non-committed workflow, including commands to generate artifacts locally and retrieve them from CI builds.
+   - Note the new gitignore policy and how to clear stale artifacts.
+
+6. **Adjust CI and GitHub Action outputs**
+   - Update the private GitHub Action (`.github/actions/proxmox-openapi-artifacts`) and any workflows invoking it to upload the generated specs as artifacts instead of expecting git diffs.
+   - Ensure the automation pipeline job cleans the artifact directory before each run to prevent cross-run contamination.
+   - Extend workflow steps to publish SHA-256 summaries so reviewers can compare changes without the spec committed.
+
+7. **Remove committed artifacts and enforce policy**
+   - Delete `docs/openapi/proxmox-ve.{json,yaml}` from source control.
+   - Add lint/test guard (e.g., a Vitest or script under `npm run lint`) that fails if files under `docs/openapi/` are reintroduced.
+   - Provide a developer migration note in `versions/` changelog when the refactor merges.
+
+8. **Rollout & QA**
+   - Validate locally by running `npm run automation:pipeline` and confirming the Remix UI loads `/openapi.json` using the generated artifact.
+   - Run regression tests and ensure they still validate checksums derived from the generated files.
+   - In CI, verify the workflow publishes downloadable artifacts and that downstream consumers (if any) can ingest them via the new distribution channel.
+
+## Risks and mitigations
+- **Risk**: Developers may forget to run the pipeline locally and encounter 404s in the UI.
+  - *Mitigation*: Improve loader error messages, add README reminders, and optionally include a convenience script (`npm run openapi:prepare`) that runs the pipeline in CI mode.
+- **Risk**: Regression suite order dependence if artifacts are missing.
+  - *Mitigation*: Add explicit setup steps that ensure the automation pipeline runs (or the summary file exists) before checksum assertions execute.
+- **Risk**: Downstream automation relying on committed files breaks.
+  - *Mitigation*: Communicate the new artifact location, update any integration scripts, and provide a transitional branch or compatibility shim that copies generated specs into expected locations when needed.
+
+## Follow-up considerations
+- Evaluate compressing and uploading artifacts to long-term storage (e.g., GitHub Releases) if consumers require stable download URLs.
+- Consider generating a minimal JSON schema diff report to help reviewers compare spec changes without the full file committed.
+- Explore using git-lfs or release assets if file sizes grow and CI artifact retention becomes a concern.

--- a/tasks/TASK-0034-openapi-spec-output-plan.md
+++ b/tasks/TASK-0034-openapi-spec-output-plan.md
@@ -1,0 +1,89 @@
+Title
+- Plan to externalize OpenAPI spec artifacts
+
+Source of truth
+- plan/proxmox-openapi-extraction-plan.md
+- docs/handover/README.md
+- docs/automation/README.md
+
+Scope
+- Focus: project-wide automation, tooling, docs updates for OpenAPI artifacts
+- Out of scope: product code unrelated to artifact generation, external services
+- Data model and types: Intermediate representation and OpenAPI generator types are canonical
+
+Allowed changes
+- Documentation and tooling plans affecting artifact generation
+- Shared utilities if required to describe plan steps
+- No schema or data model edits in this planning task
+
+Branch
+- feature/20251001---task-0034-openapi-spec-output-plan
+
+Preconditions
+- Run: source .env (if exists)
+- Ensure required CLIs authenticated
+- Confirm repository PR template and standard scripts available
+
+Plan checklist
+- [x] Read the Source of Truth in order. Extract requirements into a short list.
+- [ ] If the project syncs schema or types from a remote system, trigger the sync on the target branch.
+      - [ ] gh workflow run "<WORKFLOW NAME>" --ref <BRANCH>
+      - [ ] Verify updated schema, seed data, and generated types.
+- [ ] Audit the current implementation in the focus area.
+      - [ ] Trace data flow from settings or inputs through persistence to output.
+      - [ ] Identify missing mappings or dead configuration.
+- [ ] Implement changes with small, focused commits.
+      - [ ] Keep models aligned with generated types or schemas.
+      - [ ] Remove unused config and wire only supported options end to end.
+- [ ] Wire persistence and retrieval.
+      - [ ] Validate input values.
+      - [ ] Persist to storage or API and read back.
+      - [ ] Handle undefined and default values.
+- [ ] Tests and checks.
+      - [ ] source .env
+      - [ ] Install dependencies.
+      - [ ] Run linter.
+      - [ ] Build project or artifacts.
+      - [ ] Run unit and integration tests.
+- [ ] Functional QA.
+      - [ ] Verify expected behavior on key user flows or endpoints.
+      - [ ] Confirm no regressions in critical paths.
+- [ ] Documentation.
+      - [ ] Update docs only if behavior changed. Keep changes concise.
+- [ ] Commits using Conventional Commits.
+      - [ ] feat(...), fix(...), chore(...), docs(...), refactor(...)
+- [ ] Open PR.
+      - [ ] Use the repo PR template.
+      - [ ] Title: feat: TASK-0034 Plan to externalize OpenAPI spec artifacts
+      - [ ] Body: link this task file, paste checklist, tick completed items, list deferrals.
+- [ ] Changelog.
+      - [ ] Create versions/CHANGELOG-TASK-0034-<PR or short hash>-1.md
+      - [ ] Include the command log, key decisions, and outcomes.
+- [ ] Done.
+      - [ ] Mark remaining boxes as - [ ] (defer) with reasons.
+
+Acceptance criteria
+- Requirements from the Source of Truth are implemented and testable.
+- Models align with the canonical schema and generated types.
+- All acceptance commands pass.
+- Behavior is verified by QA steps relevant to the change.
+- PR is open with template, checklist, and task link.
+- Changelog file exists and is human readable.
+
+Acceptance commands template
+- Environment
+  - source .env (if exists)
+- Optional schema or types sync
+  - Trigger CI/CLI sync if applicable and verify updated artifacts.
+- Install and checks
+  - Install dependencies
+  - Run linter
+  - Build artifacts
+- Tests
+  - Run unit tests
+  - Run integration and/or end-to-end tests as applicable
+
+Requirements summary
+- Pipeline currently commits generated specs under `docs/openapi/` and documentation expects git diffs for review.
+- Automation, regression tests, and the Remix UI rely on those committed files for runtime behaviour.
+- Future workflow must allow deterministic generation while distributing artifacts via local runs or CI-produced outputs, not version control.

--- a/versions/CHANGELOG-TASK-0034-PR-1.md
+++ b/versions/CHANGELOG-TASK-0034-PR-1.md
@@ -1,0 +1,22 @@
+# TASK-0034 Plan to externalize OpenAPI spec artifacts (Revision 1)
+
+## Summary
+- Created task plan describing how to remove committed OpenAPI specs and rely on generated artifacts.
+- Documented current pipeline, UI, and regression dependencies on `docs/openapi/` outputs.
+- Outlined phased refactor covering tooling defaults, regression baselines, CI workflows, and developer documentation updates.
+
+## Command log
+```shell
+find .. -name AGENTS.md -print
+ls tasks
+cat package.json
+sed -n '1,200p' tools/openapi-generator/src/cli.ts
+sed -n '1,200p' tools/automation/src/pipeline.ts
+sed -n '1,200p' tests/regression/artifacts.spec.ts
+sed -n '1,200p' tools/automation/src/regression/baselines.ts
+sed -n '1,160p' docs/handover/README.md
+sed -n '1,160p' docs/automation/README.md
+```
+
+## Notes
+- No code changes were implemented; this revision captures the forward-looking refactor plan only.


### PR DESCRIPTION
## Summary
- add TASK-0034 tracker entry documenting scope and requirements for removing committed OpenAPI specs
- capture a detailed refactor plan covering tooling defaults, regression baselines, CI, and documentation updates
- log supporting discovery commands in the task changelog for future implementation work

## Testing
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] `npm test`

## Task Reference
- [x] Linked task: [TASK-0034](../tasks/TASK-0034-openapi-spec-output-plan.md)

## Checklist
- [x] Sources read in order
- [ ] Canonical schema and types verified or synced
- [x] Implementation aligned with requirements
- [ ] Tests, lint, build passed
- [ ] QA completed for key flows
- [x] Changelog created
- [ ] Deferrals documented if any

## Notes
- Planning-only change; no automated checks were executed.


------
https://chatgpt.com/codex/tasks/task_e_68dd59946a6483238a208af1fb344f0c