### PR TITLE
feat: TASK-0046 release guard for schema duplicates

### DIFF
--- a/.github/workflows/private-action-release.yml
+++ b/.github/workflows/private-action-release.yml
@@ -41,20 +41,112 @@ jobs:
         run: npm run action:install
       - name: Lint and typecheck action workspace
         run: npm run action:package
+  release_guard:
+    name: Evaluate release trigger
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.decision.outputs.should_release }}
+      pve_version: ${{ steps.metadata.outputs.version }}
+      pve_updated_at: ${{ steps.metadata.outputs.updated_at }}
+      pve_metadata: ${{ steps.metadata.outputs.metadata }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Discover Proxmox docs metadata
+        id: metadata
+        run: |
+          set -euo pipefail
+          python - <<'PY' > pve-metadata.json
+import json
+import re
+import urllib.request
+
+URL = "https://pve.proxmox.com/pve-docs/"
+data = {}
+try:
+    with urllib.request.urlopen(URL, timeout=30) as response:
+        html = response.read().decode("utf-8", "replace")
+except Exception as exc:  # pragma: no cover - diagnostic path
+    data["error"] = str(exc)
+else:
+    text = re.sub(r"<[^>]+>", " ", html)
+    text = text.replace("&nbsp;", " ")
+    text = " ".join(text.split())
+    version_match = re.search(r"Version\s+([0-9]+(?:\.[0-9]+)*)", text)
+    if version_match:
+        data["version"] = version_match.group(1)
+    updated_match = re.search(r"Last updated\s+([A-Za-z]{3}\s+[A-Za-z]{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\S+\s+\d{4})", text)
+    if updated_match:
+        data["updated_at"] = " ".join(updated_match.group(1).split())
+print(json.dumps(data))
+PY
+          cat pve-metadata.json
+          VERSION="$(jq -r '.version // empty' pve-metadata.json)"
+          UPDATED="$(jq -r '.updated_at // empty' pve-metadata.json)"
+          ERROR_MESSAGE="$(jq -r '.error // empty' pve-metadata.json)"
+          if [ -z "$VERSION" ]; then
+            VERSION="unknown"
+          fi
+          if [ -z "$UPDATED" ]; then
+            UPDATED="unknown"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "updated_at=$UPDATED" >> "$GITHUB_OUTPUT"
+          echo "metadata=$(jq -c '.' pve-metadata.json)" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Proxmox docs metadata"
+            echo "- Version: $VERSION"
+            echo "- Last updated: $UPDATED"
+            if [ -n "$ERROR_MESSAGE" ]; then
+              echo "- Fetch error: $ERROR_MESSAGE"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Evaluate release guard
+        id: decision
+        run: |
+          set -euo pipefail
+          SHOULD_RELEASE="true"
+          EVENT_NAME="$GITHUB_EVENT_NAME"
+          PVE_VERSION="${{ steps.metadata.outputs.version }}"
+          if [ "$PVE_VERSION" = "" ] || [ "$PVE_VERSION" = "unknown" ]; then
+            PVE_VERSION=""
+          fi
+          if [ "$EVENT_NAME" = "push" ] && [ -n "$PVE_VERSION" ]; then
+            git fetch --tags --force >/dev/null 2>&1 || true
+            if git tag --list "schema-*-pve-$PVE_VERSION" | grep -q .; then
+              SHOULD_RELEASE="false"
+              {
+                echo "## Release guard"
+                echo "- Skipping release: schema tag for PVE version $PVE_VERSION already exists."
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+          if [ "$SHOULD_RELEASE" = "true" ]; then
+            {
+              echo "## Release guard"
+              echo "- Proceeding with release automation."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "should_release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
   release_action:
     name: Publish action release
-    needs: validate
-    if: ${{ success() }}
+    needs:
+      - validate
+      - release_guard
+    if: ${{ needs.validate.result == 'success' && needs.release_guard.outputs.should_release == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
     outputs:
       action_tag: ${{ steps.metadata.outputs.action_tag }}
-      schema_tag: ${{ steps.metadata.outputs.schema_tag }}
+      release_version: ${{ steps.metadata.outputs.release_version }}
       generate_notes: ${{ steps.metadata.outputs.generate_notes }}
       is_prerelease: ${{ steps.metadata.outputs.is_prerelease }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -74,20 +166,71 @@ jobs:
             REQUESTED_VERSION="$(jq -r '.inputs.version // ""' "$GITHUB_EVENT_PATH")"
             GENERATE_NOTES="$(jq -r '.inputs["generate-notes"] // "true"' "$GITHUB_EVENT_PATH")"
           fi
+
+          normalize_version() {
+            local raw="$1"
+            if [[ "$raw" =~ ^v[0-9]+\.[0-9]+\.[0-9A-Za-z.+-]+$ ]]; then
+              echo "$raw"
+              return 0
+            fi
+            echo "Error: version '$raw' must start with 'v' and follow semantic versioning (e.g., v0.3.1)." >&2
+            return 1
+          }
+
+          LAST_TAG=""
+          SOURCE_MODE="automatic"
+
           if [ -n "$REQUESTED_VERSION" ]; then
-            ACTION_TAG="$REQUESTED_VERSION"
-            SCHEMA_TAG="schema-$REQUESTED_VERSION"
-            IS_PRERELEASE="false"
+            RELEASE_VERSION="$(normalize_version "$REQUESTED_VERSION")"
+            ACTION_TAG="$RELEASE_VERSION"
+            SOURCE_MODE="manual"
           else
-            SHORT="${GITHUB_SHA::7}"
-            ACTION_TAG="action-$SHORT"
-            SCHEMA_TAG="schema-$SHORT"
-            IS_PRERELEASE="true"
+            LAST_TAG="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n1)"
+            if [ -z "$LAST_TAG" ]; then
+              RELEASE_VERSION="v0.1.0"
+            else
+              RELEASE_VERSION="$(LAST_TAG="$LAST_TAG" python - <<'PY'
+import os
+import re
+tag = os.environ.get("LAST_TAG", "").strip()
+match = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", tag)
+if not match:
+    raise SystemExit(f"Unsupported existing tag format: {tag!r}")
+major, minor, patch = map(int, match.groups())
+patch += 1
+print(f"v{major}.{minor}.{patch}")
+PY
+)"
+            fi
+            ACTION_TAG="$RELEASE_VERSION"
           fi
+
+          if git rev-parse "$ACTION_TAG" >/dev/null 2>&1; then
+            echo "Release tag '$ACTION_TAG' already exists. Specify a new version." >&2
+            exit 1
+          fi
+
+          if [[ "$ACTION_TAG" == *-* ]]; then
+            IS_PRERELEASE="true"
+          else
+            IS_PRERELEASE="false"
+          fi
+
           echo "action_tag=$ACTION_TAG" >> "$GITHUB_OUTPUT"
-          echo "schema_tag=$SCHEMA_TAG" >> "$GITHUB_OUTPUT"
+          echo "release_version=$ACTION_TAG" >> "$GITHUB_OUTPUT"
           echo "generate_notes=$GENERATE_NOTES" >> "$GITHUB_OUTPUT"
           echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Release metadata"
+            echo "- Selected tag: $ACTION_TAG"
+            if [ -n "$LAST_TAG" ]; then
+              echo "- Previous stable tag: $LAST_TAG"
+            fi
+            echo "- Mode: $SOURCE_MODE"
+            echo "- Generate notes: $GENERATE_NOTES"
+            echo "- Prerelease: $IS_PRERELEASE"
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Package action directory
         run: |
           set -euo pipefail
@@ -129,7 +272,8 @@ jobs:
     needs:
       - validate
       - release_action
-    if: ${{ success() }}
+      - release_guard
+    if: ${{ needs.release_action.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -145,6 +289,60 @@ jobs:
         run: npm ci
       - name: Generate OpenAPI artifacts
         run: npm run automation:pipeline -- --mode=ci --report var/automation-summary.json
+      - name: Prepare Proxmox docs metadata
+        id: pve
+        env:
+          PVE_METADATA: ${{ needs.release_guard.outputs.pve_metadata }}
+        run: |
+          set -euo pipefail
+          if [ -n "$PVE_METADATA" ] && [ "$PVE_METADATA" != "null" ]; then
+            printf '%s' "$PVE_METADATA" | jq . > pve-metadata.json
+          else
+            python - <<'PY' > pve-metadata.json
+import json
+import re
+import urllib.request
+
+URL = "https://pve.proxmox.com/pve-docs/"
+data = {}
+try:
+    with urllib.request.urlopen(URL, timeout=30) as response:
+        html = response.read().decode("utf-8", "replace")
+except Exception as exc:  # pragma: no cover - diagnostic path
+    data["error"] = str(exc)
+else:
+    text = re.sub(r"<[^>]+>", " ", html)
+    text = text.replace("&nbsp;", " ")
+    text = " ".join(text.split())
+    version_match = re.search(r"Version\s+([0-9]+(?:\.[0-9]+)*)", text)
+    if version_match:
+        data["version"] = version_match.group(1)
+    updated_match = re.search(r"Last updated\s+([A-Za-z]{3}\s+[A-Za-z]{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\S+\s+\d{4})", text)
+    if updated_match:
+        data["updated_at"] = " ".join(updated_match.group(1).split())
+print(json.dumps(data))
+PY
+          fi
+          cat pve-metadata.json
+          VERSION="$(jq -r '.version // empty' pve-metadata.json)"
+          UPDATED="$(jq -r '.updated_at // empty' pve-metadata.json)"
+          ERROR_MESSAGE="$(jq -r '.error // empty' pve-metadata.json)"
+          if [ -z "$VERSION" ]; then
+            VERSION="unknown"
+          fi
+          if [ -z "$UPDATED" ]; then
+            UPDATED="unknown"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "updated_at=$UPDATED" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Proxmox docs metadata"
+            echo "- Version: $VERSION"
+            echo "- Last updated: $UPDATED"
+            if [ -n "$ERROR_MESSAGE" ]; then
+              echo "- Fetch error: $ERROR_MESSAGE"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Package schema artifacts
         run: |
           set -euo pipefail
@@ -155,14 +353,25 @@ jobs:
       - name: Create schema release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ needs.release_action.outputs.release_version }}
+          GENERATE_NOTES: ${{ needs.release_action.outputs.generate_notes }}
+          PRERELEASE: ${{ needs.release_action.outputs.is_prerelease }}
+          PVE_VERSION: ${{ steps.pve.outputs.version }}
+          PVE_UPDATED_AT: ${{ steps.pve.outputs.updated_at }}
         run: |
           set -euo pipefail
-          TAG="${{ needs.release_action.outputs.schema_tag }}"
-          GENERATE_NOTES="${{ needs.release_action.outputs.generate_notes }}"
-          PRERELEASE="${{ needs.release_action.outputs.is_prerelease }}"
+          if [ -z "$RELEASE_VERSION" ]; then
+            echo "Missing release version from action job." >&2
+            exit 1
+          fi
+          SCHEMA_TAG="schema-$RELEASE_VERSION"
+          if [ -n "$PVE_VERSION" ] && [ "$PVE_VERSION" != "unknown" ]; then
+            SCHEMA_TAG+="-pve-$PVE_VERSION"
+          fi
           ARGS=(
-            "$TAG"
+            "$SCHEMA_TAG"
             "proxmox-openapi-schema.zip"
+            "pve-metadata.json"
           )
           if [ "$GENERATE_NOTES" = "true" ]; then
             ARGS+=("--generate-notes")

--- a/docs/handover/README.md
+++ b/docs/handover/README.md
@@ -137,7 +137,10 @@ Follow this cadence before merging or releasing updated artifacts:
 3. **Update documentation**: Note the Proxmox API viewer date/build in commit messages or release
    notes if exposed by the upstream source.
 4. **Tag consumer-facing releases**: When publishing downstream packages or specs, follow semantic
-   versioning aligned with upstream Proxmox releases (e.g., `v8.3.0-openapi.1`).
+   versioning aligned with upstream Proxmox releases (e.g., `v8.3.0-openapi.1`). The
+   `private-action-release` workflow automatically increments the patch component when no explicit
+   version is supplied; provide the `version` input on manual runs to override the computed tag or to
+   cut prereleases (for example `v9.0.0-rc.1`).
 5. **Changelog capture**: Record the pipeline commands executed, validation results, and manual
    verification outcomes in the task-specific changelog under `versions/`.
 6. **QA sign-off**: Ensure the regression checklist items are checked (or deferred with rationale) in
@@ -146,19 +149,19 @@ Follow this cadence before merging or releasing updated artifacts:
 ### 6.1 Private GitHub Action releases
 
 - Trigger the `private-action-release` workflow via the GitHub UI when the action or automation
-  tooling changes. Provide a semantic tag (for example `v0.3.0`) to create a stable release; omit the
-  tag for prerelease builds tied to the current commit SHA.
-- The workflow validates linting/builds and now publishes two releases from separate jobs:
+  tooling changes. Provide a semantic tag (for example `v0.3.0`) to force a specific release number;
+  omit the input to let the workflow bump the previous `vX.Y.Z` tag automatically.
+- The workflow validates linting/builds and publishes two releases from separate jobs:
   - `release_action` packages the TypeScript action workspace (`action.yml`, `src/`, `tsconfig.json`,
-    `package.json`, `package-lock.json`) and creates the GitHub release tag (`v0.x.y` or the auto-generated
-    `action-<sha>` when no tag is provided) with the `proxmox-openapi-action.zip` asset.
-  - `release_schema` regenerates the OpenAPI artifacts in CI mode and publishes a companion release
-    tagged `schema-<version>` (or `schema-<sha>` for prereleases) containing a `proxmox-openapi-schema.zip`
-    archive with the JSON and YAML specs for consumers focused on the schema alone.
+    `package.json`, `package-lock.json`) and tags the release with the resolved semantic version.
+  - `release_schema` regenerates the OpenAPI artifacts in CI mode, detects the upstream Proxmox docs
+    version from `https://pve.proxmox.com/pve-docs/`, and publishes a companion release tagged
+    `schema-<version>-pve-<docsVersion>`. The job uploads both the zipped OpenAPI artifacts and a
+    `pve-metadata.json` file capturing the upstream version and "Last updated" timestamp so consumers can
+    audit the source state.
   The action archive ships the TypeScript sources and lockfile so runners install dependencies on demand
   before executing `src/main.ts` with `tsx`.
-- Downstream repositories can pin to specific tags or prereleases depending on stability
-  requirements.
+- Downstream repositories can pin to specific tags or prereleases depending on stability requirements.
 
 ## 7. Troubleshooting guide
 

--- a/tasks/TASK-0045-release-versioning-strategy.md
+++ b/tasks/TASK-0045-release-versioning-strategy.md
@@ -1,0 +1,86 @@
+Title
+- Define release version automation strategy.
+
+Source of truth
+- plan/private-github-action-plan.md
+- plan/private-action-release-dist-sync.md
+- docs/handover/README.md
+- docs/automation/README.md
+
+Scope
+- Focus areas. .github/workflows/
+- Out of scope. app/, tools/, docs/ (except workflow notes if necessary)
+- Data model and types. Automation pipeline outputs and committed action dist remain canonical.
+
+Allowed changes
+- Update release workflow configuration and supporting automation docs.
+- Adjust repository documentation referencing the workflow, if behaviour changes.
+- No changes to application runtime code or schemas beyond workflow automation.
+
+Branch
+- feature/2025-10-02---task-0045-release-versioning-strategy
+
+Preconditions
+- Run: source .env (if exists)
+- Ensure required CLIs are authenticated. Example: gh, test runners, deployment tools.
+- Confirm the repository has the PR template and standard scripts.
+
+Plan checklist
+- [x] Read the Source of Truth in order. Extract requirements into a short list.
+- [ ] (defer) If the project syncs schema or types from a remote system, trigger the sync on the target branch. Not required for this workflow-focused change.
+      Example with GitHub CLI:
+      - [ ] (defer) gh workflow run "<WORKFLOW NAME>" --ref <BRANCH>. Not applicable.
+      - [ ] (defer) Verify updated schema, seed data, and generated types. Not applicable.
+- [x] Audit the current implementation in the focus area.
+      - [x] Trace data flow from settings or inputs through persistence to output.
+      - [x] Identify missing mappings or dead configuration.
+- [x] Implement changes with small, focused commits.
+      - [x] Keep models aligned with generated types or schemas.
+      - [x] Remove unused config and wire only supported options end to end.
+- [ ] (defer) Wire persistence and retrieval. Workflow change only; no data layer involved.
+      - [ ] (defer) Validate input values. Not applicable.
+      - [ ] (defer) Persist to storage or API and read back. Not applicable.
+      - [ ] (defer) Handle undefined and default values. Not applicable.
+- [x] Tests and checks.
+      - [x] source .env
+      - [x] Install dependencies.
+      - [x] Run linter.
+      - [x] Build project or artifacts.
+      - [x] Run unit and integration tests.
+- [ ] (defer) Functional QA.
+      - [ ] (defer) Verify expected behavior on key user flows or endpoints. Requires live GitHub workflow execution.
+      - [ ] (defer) Confirm no regressions in critical paths. Requires live GitHub workflow execution.
+- [x] Documentation.
+      - [x] Update docs only if behavior changed. Keep changes concise.
+- [x] Commits using Conventional Commits.
+      - [x] feat(...), fix(...), chore(...), docs(...), refactor(...)
+- [x] Open PR.
+      - [x] Use the repo PR template.
+      - [x] Title: feat: TASK-0045 {short description}
+      - [x] Body: link this task file, paste checklist, tick completed items, list deferrals.
+- [x] Changelog.
+      - [x] Create versions/CHANGELOG-TASK-0045-{PR or short hash}-1.md
+      - [x] Include the command log, key decisions, and outcomes.
+- [x] Done.
+      - [x] Mark remaining boxes as - [ ] (defer) with reasons.
+
+Acceptance criteria
+- Requirements from the Source of Truth are implemented and testable.
+- Models align with the canonical schema and generated types.
+- All acceptance commands pass.
+- Behavior is verified by QA steps relevant to the change.
+- PR is open with template, checklist, and task link.
+- Changelog file exists and is human readable.
+
+Acceptance commands template
+- Environment
+  - source .env (if exists)
+- Optional schema or types sync
+  - Trigger CI/CLI sync if applicable and verify updated artifacts.
+- Install and checks
+  - Install dependencies
+  - Run linter
+  - Build artifacts
+- Tests
+  - Run unit tests
+  - Run integration and/or end-to-end tests as applicable

--- a/tasks/TASK-0046-release-version-check.md
+++ b/tasks/TASK-0046-release-version-check.md
@@ -1,0 +1,85 @@
+Title
+- Prevent duplicate releases based on Proxmox docs version.
+
+Source of truth
+- plan/private-github-action-plan.md
+- plan/private-action-release-dist-sync.md
+- tasks/TASK-0045-release-versioning-strategy.md
+
+Scope
+- Focus areas. `.github/workflows/private-action-release.yml`.
+- Out of scope. Everything else unless required by workflow logic.
+- Data model and types. Use existing workflow inputs and environment variables as the ground truth.
+
+Allowed changes
+- Workflow updates under `.github/workflows`.
+- Shared utilities if strictly needed (non breaking additions only).
+- No schema edits.
+
+Branch
+- feature/20240604---task-0046-release-version-check
+
+Preconditions
+- Run: source .env (if exists)
+- Ensure required CLIs are authenticated.
+- Confirm repository has PR template and standard scripts.
+
+Plan checklist
+- [x] Read the Source of Truth in order. Extract requirements into a short list.
+- [ ] (defer) If the project syncs schema or types from a remote system, trigger the sync on the target branch. Workflow-only change; no schema sync available from this environment.
+      Example with GitHub CLI:
+      - [ ] (defer) gh workflow run "<WORKFLOW NAME>" --ref <BRANCH>. Not applicable.
+      - [ ] (defer) Verify updated schema, seed data, and generated types. Not applicable.
+- [x] Audit the current implementation in the focus area.
+      - [x] Trace data flow from settings or inputs through persistence to output.
+      - [x] Identify missing mappings or dead configuration.
+- [x] Implement changes with small, focused commits.
+      - [x] Keep models aligned with generated types or schemas.
+      - [x] Remove unused config and wire only supported options end to end.
+- [ ] (defer) Wire persistence and retrieval. Workflow change only; no storage layer involved.
+      - [ ] (defer) Validate input values. Not applicable.
+      - [ ] (defer) Persist to storage or API and read back. Not applicable.
+      - [ ] (defer) Handle undefined and default values. Not applicable.
+- [x] Tests and checks.
+      - [x] source .env
+      - [x] Install dependencies.
+      - [x] Run linter.
+      - [x] Build project or artifacts.
+      - [x] Run unit and integration tests.
+- [ ] (defer) Functional QA.
+      - [ ] (defer) Verify expected behavior on key user flows or endpoints. Requires GitHub-hosted workflow execution.
+      - [ ] (defer) Confirm no regressions in critical paths. Requires GitHub-hosted workflow execution.
+- [ ] (n/a) Documentation.
+      - [ ] (n/a) Update docs only if behavior changed. Not required for this workflow-only change.
+- [x] Commits using Conventional Commits.
+      - [x] feat(...), fix(...), chore(...), docs(...), refactor(...)
+  - [x] Open PR.
+        - [x] Use the repo PR template.
+        - [x] Title: feat: TASK-0046 {short description}
+        - [x] Body: link this task file, paste checklist, tick completed items, list deferrals.
+- [x] Changelog.
+      - [x] Create versions/CHANGELOG-TASK-0046-{PR or short hash}-1.md
+      - [x] Include the command log, key decisions, and outcomes.
+  - [x] Done.
+        - [x] Mark remaining boxes as - [ ] (defer) with reasons.
+
+Acceptance criteria
+- Requirements from the Source of Truth are implemented and testable.
+- Models align with the canonical schema and generated types.
+- All acceptance commands pass.
+- Behavior is verified by QA steps relevant to the change.
+- PR is open with template, checklist, and task link.
+- Changelog file exists and is human readable.
+
+Acceptance commands template
+- Environment
+  - source .env (if exists)
+- Optional schema or types sync
+  - Trigger CI/CLI sync if applicable and verify updated artifacts.
+- Install and checks
+  - Install dependencies
+  - Run linter
+  - Build artifacts
+- Tests
+  - Run unit tests
+  - Run integration and/or end-to-end tests as applicable

--- a/versions/CHANGELOG-TASK-0045-PR-1.md
+++ b/versions/CHANGELOG-TASK-0045-PR-1.md
@@ -1,0 +1,22 @@
+# Changelog — TASK-0045 Release versioning strategy
+
+## Summary
+- Automated semantic version calculation in the `private-action-release` workflow with manual override support and publish-time validation guards.
+- Captured upstream Proxmox docs metadata during schema releases, attaching a JSON manifest and tagging releases with the detected version string.
+- Updated the handover guide to explain the new automatic version bumping behaviour and schema release metadata.
+
+## Command log
+- source .env (repository root)
+- npm install
+- npm run lint
+- npm run build
+- npm test
+
+## Decisions and notes
+- Default releases now bump the previous `vX.Y.Z` tag's patch component; maintainers can still supply an explicit semantic version (including prereleases) via `workflow_dispatch`.
+- Schema releases emit `schema-<version>-pve-<docsVersion>` tags and ship a `pve-metadata.json` asset so downstream consumers can align artifacts with the upstream documentation snapshot.
+- Combining generated release notes with curated metadata via `gh release create` is achieved by attaching the metadata as a separate asset to avoid conflicting CLI flags.
+
+## Deferred or follow-up work
+- Live functional QA of the GitHub workflow remains deferred until the updated release pipeline runs in GitHub Actions.
+- Schema/type synchronization is not applicable for this workflow-focused change.

--- a/versions/CHANGELOG-TASK-0046-PR-1.md
+++ b/versions/CHANGELOG-TASK-0046-PR-1.md
@@ -1,0 +1,15 @@
+# TASK-0046 — Prevent duplicate releases based on Proxmox docs version
+
+## Summary
+- Added a `release_guard` job that records Proxmox docs metadata and blocks automatic push-triggered releases when a matching schema tag already exists.
+- Reused captured metadata in the schema publishing job to avoid redundant network calls while keeping manual overrides functional.
+
+## Command log
+- `npm ci`
+- `npm run lint`
+- `npm run build`
+- `npm test`
+
+## Decisions & notes
+- Deferred functional QA to GitHub-hosted environments because the release workflow cannot be executed locally.
+- Documentation updates were not required; behaviour changes are confined to the workflow implementation.


### PR DESCRIPTION
## Summary
- add a `release_guard` job that records the upstream Proxmox docs metadata and blocks push-triggered releases when a matching schema tag already exists
- reuse the captured metadata in the schema publishing job so manual dispatches still ship `pve-metadata.json` without a second fetch

## Testing
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`

## Task Reference
- [x] Linked task: [TASK-0046](../tasks/TASK-0046-release-version-check.md)

## Checklist
- [x] Sources read in order
- [ ] Canonical schema and types verified or synced
- [x] Implementation aligned with requirements
- [x] Tests, lint, build passed
- [ ] QA completed for key flows
- [x] Changelog created
- [x] Deferrals documented if any

## Notes
- Functional QA deferred until the workflow runs in GitHub Actions because release execution cannot be validated locally.
- Schema/type sync not applicable for this workflow-only change.


------
https://chatgpt.com/codex/tasks/task_e_68df0d2428dc8323a56d3b499af8ae91