### PR TITLE
feat: TASK-0049 Update documentation audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ This repository contains tooling to scrape the [Proxmox VE API viewer](https://p
 
    This command scrapes the upstream documentation, normalizes the snapshot, generates JSON/YAML
    OpenAPI documents, and validates the output. For cached CI parity, drop the `--mode=full` flag.
+   The pipeline also supports:
+
+   - `-- --offline` to skip the live scrape and reuse the cached snapshot when reviewing historical
+     artifacts.
+   - `-- --fallback-to-cache=false` to surface scrape failures immediately in full mode instead of
+     silently reusing the cache.
+   - `-- --report <path>` to persist a JSON summary describing the raw snapshot, IR, OpenAPI outputs,
+     and cache usage.
+
+   Set `SCRAPER_BASE_URL` when targeting a staging API viewer.
 
 Refer to the [handover guide](docs/handover/README.md) for deeper documentation covering setup,
 manual QA, release planning, and troubleshooting.
@@ -36,7 +46,15 @@ manual QA, release planning, and troubleshooting.
 - `tools/api-scraper/` contains the Playwright-based scraping toolkit.
   - `playwright.config.ts` defines the Playwright test runner configuration.
   - `tests/` holds smoke and regression tests for the scraper.
-  - `src/cli.ts` is a placeholder CLI entry point that will evolve into the end-to-end scraping workflow.
+  - `src/cli.ts` provides the `npm run scraper:scrape` entry point.
+- `tools/api-normalizer/` houses the IR builder that transforms raw snapshots into a deterministic
+  intermediate representation consumed by the generator.
+- `tools/openapi-generator/` maps the normalized IR to OpenAPI 3.1 JSON and YAML artifacts.
+- `tools/automation/` orchestrates the scrape → normalize → emit workflow and includes the
+  `npm run automation:pipeline` CLI plus regression logging helpers.
+- `tools/shared/` and `tools/analysis/` host cross-cutting utilities (path resolution, regression
+  summaries) and research scripts for parity validation against upstream Perl modules.
+- `tests/regression/` implements checksum and parity assertions for generated artifacts.
 - `app/` contains a Remix + Vite sandbox for rapid UI prototyping and component experimentation.
   - `npm run ui:dev` starts the Remix-enhanced Vite development server.
   - `npm run ui:build` compiles the Remix client and server bundles into `build/`.

--- a/docs/automation/README.md
+++ b/docs/automation/README.md
@@ -15,11 +15,16 @@ step.
     viewer. Use this when you need to update the committed artifacts after the
     upstream documentation changes.
 - Additional options:
-  - `-- --base-url <url>` — target an alternate API viewer instance.
+  - `-- --base-url <url>` — target an alternate API viewer instance (or set `SCRAPER_BASE_URL`).
   - `-- --raw-output <path>` — override the persisted raw snapshot location.
   - `-- --ir-output <path>` — change the normalized IR output file.
   - `-- --openapi-dir <dir>` — redirect generated OpenAPI files (default `var/openapi/`).
   - `-- --basename <name>` — adjust the OpenAPI filename prefix.
+  - `-- --offline` — skip the live scrape and reuse the cached snapshot.
+  - `-- --fallback-to-cache=false` — propagate scrape failures instead of silently reusing the cache
+    (helpful when diagnosing upstream outages).
+  - `-- --report <path>` — write a JSON summary describing inputs, outputs, and cache usage for
+    downstream automations.
 
 ## Fallback behaviour
 
@@ -33,7 +38,8 @@ step.
 ## Verifying outputs
 
 1. Run `npm run automation:pipeline -- --mode=full` locally to fetch the latest
-   upstream data.
+   upstream data. Include `-- --report var/automation-summary.json` when you need
+   a machine-readable audit trail of the run.
 2. Inspect `tools/api-scraper/data/raw/proxmox-api-schema.json`,
    `tools/api-normalizer/data/ir/proxmox-api-ir.json`, and
    `var/openapi/proxmox-ve.(json|yaml)` for changes.
@@ -42,7 +48,7 @@ step.
 
 ## JSON summaries and automation entry point
 
-- The CLI accepts `--report <path>` to write a JSON summary describing the raw
+- The CLI accepts `-- --report <path>` to write a JSON summary describing the raw
   snapshot, normalized IR, OpenAPI outputs, and cache usage. GitHub Actions and
   other automations consume this file to surface artifact paths as workflow
   outputs.

--- a/docs/automation/private-action-adoption.md
+++ b/docs/automation/private-action-adoption.md
@@ -47,6 +47,20 @@ setups where the runner lacks cached browsers. The action installs its
 dependencies on demand and executes the TypeScript entrypoint with `tsx`, so
 downstream workflows do not need to manage a prebuilt `dist/` directory.
 
+### Key inputs
+
+- `install-command` (default `npm ci`) — customize dependency installation when
+  the repository uses workspaces or alternative package managers.
+- `working-directory` — set to the subdirectory containing `package.json` if the
+  repo embeds the automation toolkit in a monorepo.
+- `fallback-to-cache` / `offline` — mirror the CLI flags to control cache reuse
+  when the upstream viewer is unavailable.
+- `report-path` — persist the pipeline summary JSON in a known location (attach
+  to releases or cache for later diagnostics).
+- `openapi-dir`, `raw-snapshot-path`, `ir-output-path`, and `openapi-basename`
+  — override artifact locations when the repository layout differs from the
+  default checkout structure.
+
 ## 3. Sandbox validation checklist
 
 - [ ] Run the workflow in a clean repository fork using the CI mode to confirm
@@ -54,7 +68,8 @@ downstream workflows do not need to manage a prebuilt `dist/` directory.
 - [ ] Trigger the workflow with `mode: full` and `install-playwright-browsers:
       true` to ensure live scraping succeeds in the sandbox environment.
 - [ ] Upload the generated artifacts and inspect them manually to verify parity
-      with canonical outputs from this repository.
+      with canonical outputs from this repository. Include the action's
+      `summary-path` output alongside the artifacts for auditing.
 
 ## 4. Troubleshooting
 

--- a/docs/handover/README.md
+++ b/docs/handover/README.md
@@ -68,8 +68,7 @@ npm run scraper:scrape
 ```
 
 - Writes a timestamped snapshot under `tools/api-scraper/data/raw/`.
-- Use the `SCRAPER_BASE_URL` environment variable or the `-- --base-url <url>` flag to target a
-  staging or air-gapped API viewer.
+- Use the `SCRAPER_BASE_URL` environment variable to target a staging or air-gapped API viewer.
 - Logs endpoint counts so you can quickly detect large upstream shifts.
 
 ### 4.2 Normalize scraped data
@@ -101,7 +100,8 @@ npm run automation:pipeline
 ```
 
 - Default **CI mode** (`--mode=ci`) reuses cached artifacts, runs normalization + generation, and
-  validates OpenAPI output with Swagger Parser.
+  validates OpenAPI output with Swagger Parser. CI mode automatically sets `--offline` and
+  `--fallback-to-cache` so the pipeline succeeds when the upstream viewer is unreachable.
 - Use **full mode** for release refreshes:
 
   ```bash
@@ -109,10 +109,14 @@ npm run automation:pipeline
   ```
 
   - Forces a fresh Playwright scrape.
-  - Honors additional flags such as `--base-url`, `--raw-output`, `--ir-output`, and
-    `--openapi-dir` for staging scenarios.
-- When `--mode=ci` is combined with flaky connectivity, pass `--fallback-to-cache` (default) to
-  gracefully reuse the last committed snapshot.
+  - Honors additional flags such as `-- --base-url`, `-- --raw-output`, `-- --ir-output`, and
+    `-- --openapi-dir` for staging scenarios.
+  - Toggle `-- --offline` explicitly when you need the full pipeline without hitting the network in
+    full mode (for example, reviewing historic artifacts offline).
+  - Use `-- --fallback-to-cache=false` in full mode to surface scrape failures immediately instead of
+    silently reusing the previous snapshot.
+  - Append `-- --report <path>` to emit a JSON summary documenting input/output paths and cache usage
+    for audit trails or downstream automation.
 - Review the tail of the pipeline log for the regression report summary (checksums, counts, parity).
 - Generated OpenAPI files live in `var/openapi/`. Upload `proxmox-ve.json` (and optional YAML) to the
   GitHub release assets so downstream consumers can download the spec without cloning the repo.

--- a/docs/qa/regression-checklist.md
+++ b/docs/qa/regression-checklist.md
@@ -10,6 +10,7 @@ This checklist enumerates the automated and manual verifications required before
    - Asserts that JSON and YAML OpenAPI documents remain structurally identical.
 2. **Automation pipeline summary** (`npm run automation:pipeline`)
    - Emits a QA regression summary highlighting artifact checksums, coverage counts, and parity indicators during CI and local runs.
+   - When invoked with `-- --report <path>`, persists a JSON summary that downstream tooling can ingest for release notes or artifact uploads.
 
 ## Manual smoke tests
 
@@ -19,7 +20,7 @@ Perform the following validations whenever baselines are intentionally regenerat
 - [ ] **Playwright scrape spot check**: Run `npm run scraper:scrape` (with a clean cache) and confirm the resulting snapshot captures representative endpoints (e.g., `/nodes`, `/access`, `/cluster`).
 - [ ] **OpenAPI validator**: Execute `npm run openapi:validate` and confirm no schema warnings are reported.
 - [ ] **IR sampling**: Inspect a handful of normalized endpoints in `tools/api-normalizer/data/ir/proxmox-api-ir.json` to confirm security metadata and schema flags were preserved.
-- [ ] **Documentation sync**: Ensure the GitHub release assets include the refreshed `proxmox-ve.json` (and optional YAML) so downstream consumers receive the latest schema, and update references if version numbers change.
+- [ ] **Documentation sync**: Ensure the GitHub release assets include the refreshed `proxmox-ve.json` (and optional YAML) so downstream consumers receive the latest schema, and update references if version numbers change. Attach the pipeline summary JSON when available to capture source paths and cache usage.
 
 ## Escalation guidance
 

--- a/tasks/TASK-0049-docs-review.md
+++ b/tasks/TASK-0049-docs-review.md
@@ -1,0 +1,85 @@
+Title
+- Update documentation audit
+
+Source of truth
+- Product requirements and core design docs (unavailable; note for backlog)
+- AGENTS.md (none found in repository)
+- Task files (existing documentation tasks for context)
+
+Scope
+- Focus areas: docs/, README.md, public/, app/, tests/, tools/, plan/, versions/
+- Out of scope: node_modules/, .git/, .github/workflows (code-level automation unchanged)
+- Data model and types: Use existing TypeScript definitions as canonical (no schema changes)
+
+Allowed changes
+- Documentation updates across focus areas
+- Minor corrections in shared utilities only if strictly necessary for documentation accuracy
+- No schema edits
+
+Branch
+- feature/2024-05-27---task-0049-docs-review
+
+Preconditions
+- Run: source .env (if exists)
+- Ensure required CLIs are available (git, npm, vite)
+- Confirm repository has PR template and standard scripts (already present)
+
+Plan checklist
+- [x] Read the Source of Truth in order. Extract requirements into a short list. (Product requirements unavailable; noted in scope.)
+- [ ] (defer) Schema/types sync not required for documentation-only update.
+      Example with GitHub CLI:
+      - [ ] (defer) No remote workflow triggered for this documentation task.
+      - [ ] (defer) Schema artifacts unchanged; no verification necessary.
+- [x] Audit the current implementation in the focus area.
+      - [ ] (defer) Data flow review not needed for text-only edits.
+      - [ ] (defer) Configuration untouched by documentation changes.
+- [x] Implement changes with small, focused commits.
+      - [ ] (defer) No model changes required for documentation updates.
+      - [ ] (defer) Configuration untouched during documentation sweep.
+- [ ] (defer) Persistence layers not modified during documentation work.
+      - [ ] (defer) Input validation unaffected; no changes made.
+      - [ ] (defer) Storage interactions unchanged.
+      - [ ] (defer) Default handling unchanged by documentation edits.
+- [ ] (defer) Skipped automated checks for documentation-only update.
+      - [ ] (defer) Environment already sourced at session start.
+      - [ ] (defer) No dependency changes; installation skipped.
+      - [ ] (defer) Linting omitted for documentation-only edits.
+      - [ ] (defer) Build unnecessary for documentation changes.
+      - [ ] (defer) Tests not run; no functional code modified.
+- [ ] (defer) Manual QA not required for documentation refresh.
+      - [ ] (defer) User flows unaffected by documentation changes.
+      - [ ] (defer) Critical paths untouched by documentation updates.
+- [x] Documentation.
+      - [x] Update docs only if behavior changed. Keep changes concise.
+- [x] Commits using Conventional Commits.
+      - [x] feat(...), fix(...), chore(...), docs(...), refactor(...)
+- [ ] (defer) Open PR via make_pr after commit.
+      - [ ] (defer) PR template will be applied during make_pr step.
+      - [ ] (defer) Title set during make_pr execution.
+      - [ ] (defer) Checklist populated in PR body during make_pr.
+- [x] Changelog.
+      - [x] Create versions/CHANGELOG-TASK-0049-<PR or short hash>-1.md
+      - [x] Include the command log, key decisions, and outcomes.
+- [ ] (defer) Final review pending PR creation and merge process.
+      - [x] Mark remaining boxes as - [ ] (defer) with reasons.
+
+Acceptance criteria
+- Requirements from the Source of Truth are implemented and testable.
+- Models align with the canonical schema and generated types.
+- All acceptance commands pass.
+- Behavior is verified by QA steps relevant to the change.
+- PR is open with template, checklist, and task link.
+- Changelog file exists and is human readable.
+
+Acceptance commands template
+- Environment
+  - source .env (if exists)
+- Optional schema or types sync
+  - Trigger CI/CLI sync if applicable and verify updated artifacts.
+- Install and checks
+  - Install dependencies
+  - Run linter
+  - Build artifacts
+- Tests
+  - Run unit tests
+  - Run integration and/or end-to-end tests as applicable

--- a/tools/api-scraper/README.md
+++ b/tools/api-scraper/README.md
@@ -11,7 +11,9 @@ npm run scraper:scrape
 
 The command launches Chromium headlessly, retrieves the documentation bundle, parses the
 `apiSchema` payload, and writes a deterministic snapshot to
-`tools/api-scraper/data/raw/proxmox-api-schema.json`.
+`tools/api-scraper/data/raw/proxmox-api-schema.json`. Override the target by setting the
+`SCRAPER_BASE_URL` environment variable before running the command (for example, to scrape a staging
+viewer instance).
 
 The snapshot includes:
 

--- a/tools/openapi-generator/README.md
+++ b/tools/openapi-generator/README.md
@@ -15,7 +15,9 @@ produced by the normalizer and emits deterministic JSON and YAML documents in
    npm run openapi:generate
    ```
 
-   Use `-- --input <path>` or `-- --output <dir>` to override paths.
+   Use `-- --input <path>` or `-- --output <dir>` to override paths. Combine with
+   `-- --basename <name>` to change the filename prefix or `-- --format json,yaml`
+   to restrict the generated artifacts.
 3. Validate the generated specification:
 
    ```bash

--- a/versions/CHANGELOG-TASK-0049-PR-1.md
+++ b/versions/CHANGELOG-TASK-0049-PR-1.md
@@ -1,0 +1,37 @@
+# TASK-0049 – Documentation review
+
+## Summary
+- Reviewed repository documentation covering README, handover, automation, QA, and tool-specific guides.
+- Updated references to automation pipeline flags (`--offline`, `--fallback-to-cache`, `--report`) and SCRAPER_BASE_URL usage.
+- Documented private action inputs, regression checklist expectations, and generator CLI overrides.
+
+## Command log
+```
+source .env
+find .. -name AGENTS.md -print
+ls tasks
+cat <<'EOF' > tasks/TASK-0049-docs-review.md …
+git checkout -b feature/2024-05-27---task-0049-docs-review
+sed -n '1,160p' README.md
+sed -n '1,200p' docs/handover/README.md
+find docs -maxdepth 2 -type f -name '*.md'
+sed -n '1,200p' docs/automation/README.md
+cat package.json
+sed -n '1,200p' docs/research/pvesh-vs-scrape.md
+ls tools
+sed -n '1,160p' tools/api-scraper/README.md
+sed -n '1,160p' tools/api-normalizer/README.md
+sed -n '1,200p' tools/openapi-generator/README.md
+sed -n '1,160p' tools/automation/src/cli.ts
+sed -n '1,200p' tools/automation/src/pipeline.ts
+apply_patch … (multiple documentation updates)
+sed -n '100,130p' docs/handover/README.md
+rg "base-url" docs
+python - <<'PY' … (task checklist updates)
+git diff
+```
+
+## Decisions
+- Treat automation pipeline documentation as the source of truth for CLI options and align all guides accordingly.
+- Emphasize SCRAPER_BASE_URL for direct scraper runs since the CLI does not accept a base URL flag.
+- Encourage attaching the pipeline summary JSON to QA and release assets to improve audit trails.


### PR DESCRIPTION
## Summary
- Documented current automation pipeline flags and offline/report usage across the README, handover, and automation guides.
- Expanded private action onboarding docs with input guidance and regression checklist updates that call out the pipeline summary JSON.
- Clarified SCRAPER_BASE_URL usage for the scraper and described generator CLI options; recorded work in the task log and changelog.

## Testing
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] `npm test`

## Task Reference
- [x] Linked task: [TASK-0049](../tasks/TASK-0049-docs-review.md)

## Checklist
- [x] Sources read in order
- [ ] Canonical schema and types verified or synced
- [x] Implementation aligned with requirements
- [ ] Tests, lint, build passed
- [ ] QA completed for key flows
- [x] Changelog created
- [x] Deferrals documented if any

## Notes
- Documentation-only change; schema sync, automated checks, and manual QA were deferred.


------
https://chatgpt.com/codex/tasks/task_e_68df254ea0748323bab2854f074ac9b8