### PR TITLE
Publish OpenAPI docs via GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,58 @@
+name: deploy-pages
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - dev
+    paths:
+      - '.github/workflows/pages.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tools/projects/publish-pages.ts'
+      - 'tools/automation/**'
+      - 'tools/openapi-generator/**'
+      - 'tools/api-scraper/**'
+      - 'tools/api-normalizer/**'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        run: npm install
+      - name: Generate OpenAPI artifacts
+        run: npm run automation:pipeline -- --mode=ci --report var/automation-summary.json
+      - name: Prepare pages bundle
+        run: npm run pages:prepare
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: var/pages
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "openapi:validate": "tsx tools/openapi-generator/src/validate.ts",
     "automation:pipeline": "tsx tools/automation/src/cli.ts",
     "automation:summary": "tsx tools/automation/scripts/format-summary.ts",
+    "pages:prepare": "tsx tools/projects/publish-pages.ts",
     "build": "tsc --noEmit && tsc --noEmit -p app/tsconfig.json && tsc --noEmit -p tools/automation/tsconfig.json",
     "ui:dev": "remix vite:dev",
     "ui:build": "remix vite:build",

--- a/tools/projects/publish-pages.ts
+++ b/tools/projects/publish-pages.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { mkdirSync, copyFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const outputDir = path.resolve(repoRoot, 'var/pages');
+const openApiDir = path.resolve(repoRoot, 'var/openapi');
+
+mkdirSync(outputDir, { recursive: true });
+copyFileSync(path.join(openApiDir, 'proxmox-ve.json'), path.join(outputDir, 'proxmox-ve.json'));
+copyFileSync(path.join(openApiDir, 'proxmox-ve.yaml'), path.join(outputDir, 'proxmox-ve.yaml'));
+
+const html = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Proxmox VE OpenAPI</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui.css" />
+    <style>
+      body { margin: 0; }
+      #swagger-ui { height: 100vh; }
+    </style>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui-bundle.js"></script>
+    <script>
+      window.addEventListener('load', () => {
+        SwaggerUIBundle({
+          url: 'proxmox-ve.json',
+          dom_id: '#swagger-ui',
+          presets: [SwaggerUIBundle.presets.apis],
+          layout: 'BaseLayout'
+        });
+      });
+    </script>
+  </body>
+</html>`;
+
+writeFileSync(path.join(outputDir, 'index.html'), html);


### PR DESCRIPTION
## Summary
- generate a Swagger UI bundle in  (JSON/YAML + viewer) via 
> proxmox-api@0.1.0 pages:prepare
> tsx tools/projects/publish-pages.ts
- add a deploy-pages workflow that builds the automation pipeline, prepares assets, and pushes to GitHub Pages

## Testing
- npm run lint
- npm run build

Fixes #76