### PR TITLE
chore(ci): publish pages from main branch

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: {}
   push:
     branches:
-      - dev
+      - main
     paths:
       - '.github/workflows/pages.yml'
       - 'package.json'
@@ -46,7 +46,7 @@ jobs:
       - name: Prepare pages bundle
         run: npm run pages:prepare
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: var/pages
 


### PR DESCRIPTION
## Summary
Adjust the GitHub Pages deployment workflow to publish from the `main` branch now that Pages requires environment protection on deployment, and align artifact upload action with the latest major release.

## Tasks
- Update the deploy-pages workflow triggers to watch `main` instead of `dev`.
- Ensure the deploy job still builds after the branch change.
- Bump `actions/upload-pages-artifact` to `v4`.
- Spot-check documentation or references that mention the old branch trigger.

## Testing
- `gh workflow view deploy-pages --yaml`
- (Optional) `gh workflow run deploy-pages --ref main`
