### PR TITLE
fix(ui): make openapi sync optional when artifacts missing

### DIFF
--- a/tools/projects/sync-openapi-to-ui.ts
+++ b/tools/projects/sync-openapi-to-ui.ts
@@ -6,10 +6,19 @@ const repoRoot = process.cwd();
 const sourceJson = resolve(repoRoot, "var/openapi/proxmox-ve.json");
 const sourceYaml = resolve(repoRoot, "var/openapi/proxmox-ve.yaml");
 
+const requireArtifacts = process.argv.includes("--require-artifacts");
+
 if (!existsSync(sourceJson) || !existsSync(sourceYaml)) {
-  throw new Error(
-    "OpenAPI artifacts not found in var/openapi. Run `npm run automation:pipeline` (or the relevant generators) before syncing UI assets."
+  if (requireArtifacts || process.env.UI_SYNC_REQUIRE_ARTIFACTS === "true") {
+    throw new Error(
+      "OpenAPI artifacts not found in var/openapi. Run `npm run automation:pipeline` (or the relevant generators) before syncing UI assets."
+    );
+  }
+
+  console.warn(
+    "[ui:sync-openapi] Skipping copy because var/openapi artifacts are missing. Run `npm run automation:pipeline` to generate them."
   );
+  process.exit(0);
 }
 
 const destination = resolve(repoRoot, "public/openapi.json");


### PR DESCRIPTION
## Summary
Make the `ui:sync-openapi` helper resilient when the OpenAPI artifacts are absent so CI workflows that don't generate specs (e.g., private-action-release validation) can still run `npm run ui:build` as part of the type-check pipeline.

## Tasks
- Update `tools/projects/sync-openapi-to-ui.ts` to detect missing artifacts and no-op with a warning instead of throwing.
- Optionally add a `--require-artifacts` flag if hard failure is needed locally.
- Verify private-action-release validate job logic still benefits from the change.

## Testing
- `npm run ui:sync-openapi` (with and without artifacts present)
- `npm run build`
