### PR TITLE
Ensure private-action smoke test preps output files

### DIFF
--- a/.github/workflows/private-action-release.yml
+++ b/.github/workflows/private-action-release.yml
@@ -299,6 +299,7 @@ jobs:
           export INPUT_WORKING_DIRECTORY=.
           export INPUT_REPORT_PATH="$RUNNER_TEMP/summary.json"
           mkdir -p "$RUNNER_TEMP" "$RUNNER_TOOL_CACHE"
+          touch "$GITHUB_OUTPUT" "$GITHUB_STEP_SUMMARY"
           ENTRY="$ACTION_DIR/dist/index.cjs"
           if [ ! -f "$ENTRY" ]; then
             ENTRY="$ACTION_DIR/dist/index.js"


### PR DESCRIPTION
## Summary
- touch GITHUB_OUTPUT and GITHUB_STEP_SUMMARY before running the action bundle during smoke tests
- keeps private-action-release validation happy on GitHub Actions runners

## Testing
- npm run build
